### PR TITLE
Topic/learning separation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/ambiata/x.git
 [submodule "lib/p"]
 	path = lib/p
-	url = https://github.com/ambiata/p.git
+	url = https://github.com/ambiata/p
 [submodule "lib/disorder.hs"]
 	path = lib/disorder.hs
 	url = https://github.com/ambiata/disorder.hs.git

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Five is right out.
 Grenade is a dependently typed, practical, and pretty quick neural network library for concise and precise
 specifications of complex networks in Haskell.
 
-As an example, a network which can achieve less than 1.5% error on mnist can be specified and
+As an example, a network which can achieve less than 1.5% error on MNIST can be specified and
 initialised with random weights in under 10 lines of code with
 ```haskell
-randomMnistNet :: MonadRandom m => m (Network Identity '[('D2 28 28), ('D3 24 24 10), ('D3 12 12 10), ('D3 12 12 10), ('D3 8 8 16), ('D3 4 4 16), ('D1 256), ('D1 256), ('D1 80), ('D1 80), ('D1 10), ('D1 10)])
+randomMnistNet :: MonadRandom m => m (Network '[ 'D2 28 28, 'D3 24 24 10, 'D3 12 12 10, 'D3 12 12 10, 'D3 8 8 16, 'D3 4 4 16, 'D1 256, 'D1 256, 'D1 80, 'D1 80, 'D1 10, 'D1 10])
 randomMnistNet = do
   a :: Convolution 1 10 5 5 1 1  <- randomConvolution
   let b :: Pooling 2 2 2 2        = Pooling

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -14,6 +14,7 @@ library
   build-depends:
                        base                            >= 4.8         && < 5
                      , bytestring                      == 0.10.*
+                     , async
                      , either                          == 4.4.*
                      , exceptions                      == 0.8.*
                      , hmatrix

--- a/main/feedforward.hs
+++ b/main/feedforward.hs
@@ -26,7 +26,7 @@ import           Grenade
 -- between the shapes, so inference can't do it all for us.
 
 -- With around 100000 examples, this should show two clear circles which have been learned by the network.
-randomNet :: (MonadRandom m)  => m (Network '[('D1 2), ('D1 40), ('D1 40), ('D1 10), ('D1 10), ('D1 1), ('D1 1)])
+randomNet :: (MonadRandom m)  => m (Network '[ 'D1 2, 'D1 40, 'D1 40, 'D1 10, 'D1 10, 'D1 1, 'D1 1])
 randomNet = do
   a :: FullyConnected 2 40  <- randomFullyConnected
   b :: FullyConnected 40 10 <- randomFullyConnected

--- a/main/feedforward.hs
+++ b/main/feedforward.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TupleSections         #-}
@@ -8,7 +7,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 
 import           Control.Monad
-import           Control.Monad.Identity
 import           Control.Monad.Random
 
 import           GHC.TypeLits
@@ -28,7 +26,7 @@ import           Grenade
 -- between the shapes, so inference can't do it all for us.
 
 -- With around 100000 examples, this should show two clear circles which have been learned by the network.
-randomNet :: (MonadRandom m)  => m (Network Identity '[('D1 2), ('D1 40), ('D1 40), ('D1 10), ('D1 10), ('D1 1), ('D1 1)])
+randomNet :: (MonadRandom m)  => m (Network '[('D1 2), ('D1 40), ('D1 40), ('D1 10), ('D1 10), ('D1 1), ('D1 1)])
 randomNet = do
   a :: FullyConnected 2 40  <- randomFullyConnected
   b :: FullyConnected 40 10 <- randomFullyConnected
@@ -46,13 +44,12 @@ netTest rate n = do
                    else S1D' $ fromRational 0
     net0 <- randomNet
 
-    return . runIdentity $ do
-      trained <- foldM trainEach net0 (zip inps outs)
-      let testIns = [ [ (x,y)  | x <- [0..50] ]
-                               | y <- [0..20] ]
+    let trained = foldl trainEach net0 (zip inps outs)
+    let testIns = [ [ (x,y)  | x <- [0..50] ]
+                              | y <- [0..20] ]
 
-      outMat <- traverse (traverse (\(x,y) -> (render . normx) <$> runNet trained (S1D' $ SA.vector [x / 25 - 1,y / 10 - 1]))) testIns
-      return $ unlines outMat
+    let outMat  = fmap (fmap (\(x,y) -> (render . normx) $ runNet trained (S1D' $ SA.vector [x / 25 - 1,y / 10 - 1]))) testIns
+    return $ unlines outMat
 
   where
     inCircle :: KnownNat n => SA.R n -> (SA.R n, Double) -> Bool
@@ -73,7 +70,7 @@ data FeedForwardOpts = FeedForwardOpts Int LearningParameters
 
 feedForward' :: Parser FeedForwardOpts
 feedForward' =
-  FeedForwardOpts <$> option auto (long "examples" <> short 'e' <> value 1000000)
+  FeedForwardOpts <$> option auto (long "examples" <> short 'e' <> value 100000)
                   <*> (LearningParameters
                       <$> option auto (long "train_rate" <> short 'r' <> value 0.01)
                       <*> option auto (long "momentum" <> value 0.9)

--- a/main/mnist.hs
+++ b/main/mnist.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TupleSections         #-}
@@ -9,7 +8,6 @@
 
 import           Control.Applicative
 import           Control.Monad
-import           Control.Monad.Identity
 import           Control.Monad.Random
 
 import qualified Data.Attoparsec.Text as A
@@ -32,7 +30,7 @@ import           Grenade
 
 -- With the mnist data from Kaggle normalised to doubles between 0 and 1, learning rate of 0.01 and 15 iterations,
 -- this network should get down to about a 1.3% error rate.
-randomMnistNet :: (MonadRandom m) => m (Network Identity '[('D2 28 28), ('D2 32 32), ('D3 28 28 10), ('D3 14 14 10), ('D3 14 14 10), ('D3 10 10 16), ('D3 5 5 16), ('D1 400), ('D1 400), ('D1 80), ('D1 80), ('D1 10), ('D1 10)])
+randomMnistNet :: (MonadRandom m) => m (Network '[('D2 28 28), ('D2 32 32), ('D3 28 28 10), ('D3 14 14 10), ('D3 14 14 10), ('D3 10 10 16), ('D3 5 5 16), ('D1 400), ('D1 400), ('D1 80), ('D1 80), ('D1 10), ('D1 10)])
 randomMnistNet = do
   let pad :: Pad 2 2 2 2          = Pad
   a :: Convolution 1 10 5 5 1 1  <- randomConvolution
@@ -65,8 +63,8 @@ convTest iterations trainFile validateFile rate = do
       return (S2D' $ SA.fromList pixels, S1D' $ SA.fromList lab')
 
     runIteration trainRows validateRows net i = do
-      let trained' = runIdentity $ foldM (trainEach rate) net trainRows
-      let res      = runIdentity $ traverse (\(rowP,rowL) -> (rowL,) <$> runNet trained' rowP) validateRows
+      let trained' = foldl (trainEach rate) net trainRows
+      let res      = fmap (\(rowP,rowL) -> (rowL,) $ runNet trained' rowP) validateRows
       let res'     = fmap (\(S1D' label, S1D' prediction) -> (maxIndex (SA.extract label), maxIndex (SA.extract prediction))) res
       print trained'
       putStrLn $ "Iteration " ++ show i ++ ": " ++ show (length (filter ((==) <$> fst <*> snd) res')) ++ " of " ++ show (length res')

--- a/main/mnist.hs
+++ b/main/mnist.hs
@@ -30,16 +30,15 @@ import           Grenade
 
 -- With the mnist data from Kaggle normalised to doubles between 0 and 1, learning rate of 0.01 and 15 iterations,
 -- this network should get down to about a 1.3% error rate.
-randomMnistNet :: (MonadRandom m) => m (Network '[('D2 28 28), ('D2 32 32), ('D3 28 28 10), ('D3 14 14 10), ('D3 14 14 10), ('D3 10 10 16), ('D3 5 5 16), ('D1 400), ('D1 400), ('D1 80), ('D1 80), ('D1 10), ('D1 10)])
+randomMnistNet :: MonadRandom m => m (Network '[ 'D2 28 28, 'D3 24 24 10, 'D3 12 12 10, 'D3 12 12 10, 'D3 8 8 16, 'D3 4 4 16, 'D1 256, 'D1 256, 'D1 80, 'D1 80, 'D1 10, 'D1 10])
 randomMnistNet = do
-  let pad :: Pad 2 2 2 2          = Pad
   a :: Convolution 1 10 5 5 1 1  <- randomConvolution
   let b :: Pooling 2 2 2 2        = Pooling
   c :: Convolution 10 16 5 5 1 1 <- randomConvolution
   let d :: Pooling 2 2 2 2        = Pooling
-  e :: FullyConnected 400 80     <- randomFullyConnected
+  e :: FullyConnected 256 80     <- randomFullyConnected
   f :: FullyConnected 80  10     <- randomFullyConnected
-  return $ pad :~> a :~> b :~> Relu :~> c :~> d :~> FlattenLayer :~> Relu :~> e :~> Logit :~> f :~> O Logit
+  return $ a :~> b :~> Relu :~> c :~> d :~> FlattenLayer :~> Relu :~> e :~> Logit :~> f :~> O Logit
 
 convTest :: Int -> FilePath -> FilePath -> LearningParameters -> IO ()
 convTest iterations trainFile validateFile rate = do
@@ -73,8 +72,8 @@ convTest iterations trainFile validateFile rate = do
 data MnistOpts = MnistOpts FilePath FilePath Int LearningParameters
 
 mnist' :: Parser MnistOpts
-mnist' = MnistOpts <$> (argument str (metavar "TRAIN"))
-                   <*> (argument str (metavar "VALIDATE"))
+mnist' = MnistOpts <$> argument str (metavar "TRAIN")
+                   <*> argument str (metavar "VALIDATE")
                    <*> option auto (long "iterations" <> short 'i' <> value 15)
                    <*> (LearningParameters
                        <$> option auto (long "train_rate" <> short 'r' <> value 0.01)

--- a/src/Grenade.hs
+++ b/src/Grenade.hs
@@ -1,16 +1,3 @@
-{-# LANGUAGE BangPatterns          #-}
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE KindSignatures        #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE TypeOperators         #-}
-{-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE PolyKinds             #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
-
 module Grenade (
     module X
   ) where

--- a/src/Grenade/Core/Network.hs
+++ b/src/Grenade/Core/Network.hs
@@ -26,39 +26,39 @@ data LearningParameters = LearningParameters {
 
 -- | Class for updating a layer. All layers implement this, and it is
 --   shape independent.
-class UpdateLayer (m :: * -> *) x where
+class UpdateLayer x where
   -- | The type for the gradient for this layer.
   --   Unit if there isn't a gradient to pass back.
   type Gradient x :: *
   -- | Update a layer with its gradient and learning parameters
-  runUpdate      :: LearningParameters -> x -> Gradient x -> m x
+  runUpdate      :: LearningParameters -> x -> Gradient x -> x
 
 -- | Class for a layer. All layers implement this, however, they don't
 --   need to implement it for all shapes, only ones which are appropriate.
-class UpdateLayer m x => Layer (m :: * -> *) x (i :: Shape) (o :: Shape) where
+class UpdateLayer x => Layer x (i :: Shape) (o :: Shape) where
   -- | Used in training and scoring. Take the input from the previous
   --   layer, and give the output from this layer.
-  runForwards    :: x -> S' i -> m (S' o)
+  runForwards    :: x -> S' i -> S' o
   -- | Back propagate a step. Takes the current layer, the input that the
   --   layer gave from the input and the back propagated derivatives from
   --   the layer above.
   --   Returns the gradient layer and the derivatives to push back further.
-  runBackards    :: x -> S' i -> S' o -> m (Gradient x, S' i)
+  runBackards    :: x -> S' i -> S' o -> (Gradient x, S' i)
 
 -- | Type of a network.
 --   The [Shape] type specifies the shapes of data passed between the layers.
 --   Could be considered to be a heterogeneous list of layers which are able to
 --   transform the data shapes of the network.
-data Network :: (* -> *) -> [Shape] -> * where
-    O     :: (Show x, Layer m x i o, KnownShape o, KnownShape i)
+data Network :: [Shape] -> * where
+    O     :: (Show x, Layer x i o, KnownShape o, KnownShape i)
           => !x
-          -> Network m '[i, o]
-    (:~>) :: (Show x, Layer m x i h, KnownShape h, KnownShape i)
+          -> Network '[i, o]
+    (:~>) :: (Show x, Layer x i h, KnownShape h, KnownShape i)
           => !x
-          -> !(Network m (h ': hs))
-          -> Network m (i ': h ': hs)
+          -> !(Network (h ': hs))
+          -> Network (i ': h ': hs)
 infixr 5 :~>
 
-instance Show (Network m h) where
+instance Show (Network h) where
   show (O a) = "O " ++ show a
   show (i :~> o) = show i ++ "\n:~>\n" ++ show o

--- a/src/Grenade/Core/Network.hs
+++ b/src/Grenade/Core/Network.hs
@@ -16,7 +16,6 @@ module Grenade.Core.Network (
   , LearningParameters (..)
   ) where
 
-import           Data.Typeable
 import           Grenade.Core.Shape
 
 data LearningParameters = LearningParameters {
@@ -51,10 +50,10 @@ class UpdateLayer m x => Layer (m :: * -> *) x (i :: Shape) (o :: Shape) where
 --   Could be considered to be a heterogeneous list of layers which are able to
 --   transform the data shapes of the network.
 data Network :: (* -> *) -> [Shape] -> * where
-    O     :: (Typeable x, Show x, Layer m x i o, KnownShape o, KnownShape i)
+    O     :: (Show x, Layer m x i o, KnownShape o, KnownShape i)
           => !x
           -> Network m '[i, o]
-    (:~>) :: (Typeable x, Show x, Layer m x i h, KnownShape h, KnownShape i)
+    (:~>) :: (Show x, Layer m x i h, KnownShape h, KnownShape i)
           => !x
           -> !(Network m (h ': hs))
           -> Network m (i ': h ': hs)

--- a/src/Grenade/Core/Network.hs
+++ b/src/Grenade/Core/Network.hs
@@ -1,9 +1,7 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE KindSignatures        #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE PolyKinds             #-}
@@ -14,31 +12,49 @@
 module Grenade.Core.Network (
     Layer (..)
   , Network (..)
+  , UpdateLayer (..)
+  , LearningParameters (..)
   ) where
 
+import           Data.Typeable
 import           Grenade.Core.Shape
+
+data LearningParameters = LearningParameters {
+    learningRate :: Double
+  , learningMomentum :: Double
+  , learningRegulariser :: Double
+  } deriving (Eq, Show)
+
+-- | Class for updating a layer. All layers implement this, and it is
+--   shape independent.
+class UpdateLayer (m :: * -> *) x where
+  -- | The type for the gradient for this layer.
+  --   Unit if there isn't a gradient to pass back.
+  type Gradient x :: *
+  -- | Update a layer with its gradient and learning parameters
+  runUpdate      :: LearningParameters -> x -> Gradient x -> m x
 
 -- | Class for a layer. All layers implement this, however, they don't
 --   need to implement it for all shapes, only ones which are appropriate.
-class Layer (m :: * -> *) x (i :: Shape) (o :: Shape) where
+class UpdateLayer m x => Layer (m :: * -> *) x (i :: Shape) (o :: Shape) where
   -- | Used in training and scoring. Take the input from the previous
   --   layer, and give the output from this layer.
   runForwards    :: x -> S' i -> m (S' o)
-  -- | Back propagate a step. Takes a learning rate (move from here?)
-  --   the current layer, the input that the layer gave from the input
-  --   and the back propagated derivatives from the layer above.
-  --   Returns the updated layer and the derivatives to push back further.
-  runBackards    :: Double -> x -> S' i -> S' o -> m (x, S' i)
+  -- | Back propagate a step. Takes the current layer, the input that the
+  --   layer gave from the input and the back propagated derivatives from
+  --   the layer above.
+  --   Returns the gradient layer and the derivatives to push back further.
+  runBackards    :: x -> S' i -> S' o -> m (Gradient x, S' i)
 
 -- | Type of a network.
 --   The [Shape] type specifies the shapes of data passed between the layers.
 --   Could be considered to be a heterogeneous list of layers which are able to
 --   transform the data shapes of the network.
 data Network :: (* -> *) -> [Shape] -> * where
-    O     :: (Show x, Layer m x i o, KnownShape o, KnownShape i)
+    O     :: (Typeable x, Show x, Layer m x i o, KnownShape o, KnownShape i)
           => !x
           -> Network m '[i, o]
-    (:~>) :: (Show x, Layer m x i h, KnownShape h, KnownShape i)
+    (:~>) :: (Typeable x, Show x, Layer m x i h, KnownShape h, KnownShape i)
           => !x
           -> !(Network m (h ': hs))
           -> Network m (i ': h ': hs)

--- a/src/Grenade/Core/Runner.hs
+++ b/src/Grenade/Core/Runner.hs
@@ -15,45 +15,44 @@ import           Grenade.Core.Network
 import           Grenade.Core.Shape
 
 -- | Update a network with new weights after training with an instance.
-train :: forall m i o hs. (Monad m, Head hs ~ i, Last hs ~ o, KnownShape i, KnownShape o)
+train :: forall i o hs. (Head hs ~ i, Last hs ~ o, KnownShape i, KnownShape o)
       => LearningParameters   -- ^ learning rate
       -> S' i                 -- ^ input vector
       -> S' o                 -- ^ target vector
-      -> Network m hs         -- ^ network to train
-      -> m (Network m hs)
-train rate x0 target = fmap fst . go x0
+      -> Network hs           -- ^ network to train
+      -> Network hs
+train rate x0 target = fst . go x0
   where
-    go  :: forall m' j js. (Monad m', Head js ~ j, Last js ~ o, KnownShape j)
+    go  :: forall j js. (Head js ~ j, Last js ~ o, KnownShape j)
         => S' j                -- ^ input vector
-        -> Network m' js       -- ^ network to train
-        -> m' (Network m' js, S' j)
+        -> Network js       -- ^ network to train
+        -> (Network js, S' j)
     -- handle input from the beginning, feeding upwards.
     go !x (layer :~> n)
-        = do y             <- runForwards layer x
+        = let y             = runForwards layer x
               -- run the rest of the network, and get the layer from above.
-             (n', dWs')    <- go y n
+              (n', dWs')    = go y n
               -- calculate the gradient for this layer to pass down,
-             (layer', dWs) <- runBackards layer x dWs'
+              (layer', dWs) = runBackards layer x dWs'
 
-             -- Update this layer using the gradient
-             newLayer      <- runUpdate rate layer layer'
+              -- Update this layer using the gradient
+              newLayer      = runUpdate rate layer layer'
 
-             return (newLayer :~> n', dWs)
+          in (newLayer :~> n', dWs)
 
     -- handle the output layer, bouncing the derivatives back down.
     go !x (O layer)
-        = do y                 <- runForwards layer x
+        = let y                 = runForwards layer x
               -- the gradient (how much y affects the error)
-             (layer', dWs)     <- runBackards layer x (y - target)
-             newLayer          <- runUpdate rate layer layer'
+              (layer', dWs)     = runBackards layer x (y - target)
+              newLayer          = runUpdate rate layer layer'
 
-             return (O newLayer, dWs)
+          in (O newLayer, dWs)
 
 -- | Just forwards propagation with no training.
-runNet :: forall m hs. (Monad m)
-       => Network m hs
+runNet :: Network hs
        -> S' (Head hs)         -- ^ input vector
-       -> m (S' (Last hs))     -- ^ target vector
-runNet (layer :~> n)  !x = do y <- runForwards layer x
-                              runNet n y
+       -> S' (Last hs)         -- ^ target vector
+runNet (layer :~> n)  !x = let y = runForwards layer x
+                           in  runNet n y
 runNet (O layer)      !x = runForwards layer x

--- a/src/Grenade/Core/Shape.hs
+++ b/src/Grenade/Core/Shape.hs
@@ -39,17 +39,17 @@ data Shape =
 instance KnownShape x => Num (S' x) where
   (+) (S1D' x) (S1D' y) = S1D' (x + y)
   (+) (S2D' x) (S2D' y) = S2D' (x + y)
-  (+) (S3D' x) (S3D' y) = S3D' (vectorZip (\x' y' -> x' + y') x y)
+  (+) (S3D' x) (S3D' y) = S3D' (vectorZip (+) x y)
   (+)  _ _ = error "Impossible to have different constructors for the same shaped network"
 
   (-) (S1D' x) (S1D' y) = S1D' (x - y)
   (-) (S2D' x) (S2D' y) = S2D' (x - y)
-  (-) (S3D' x) (S3D' y) = S3D' (vectorZip (\x' y' -> x' - y') x y)
+  (-) (S3D' x) (S3D' y) = S3D' (vectorZip (-) x y)
   (-)  _ _ = error "Impossible to have different constructors for the same shaped network"
 
   (*) (S1D' x) (S1D' y) = S1D' (x * y)
   (*) (S2D' x) (S2D' y) = S2D' (x * y)
-  (*) (S3D' x) (S3D' y) = S3D' (vectorZip (\x' y' -> x' * y') x y)
+  (*) (S3D' x) (S3D' y) = S3D' (vectorZip (*) x y)
   (*)  _ _ = error "Impossible to have different constructors for the same shaped network"
 
   abs (S1D' x) = S1D' (abs x)

--- a/src/Grenade/Core/Vector.hs
+++ b/src/Grenade/Core/Vector.hs
@@ -26,7 +26,7 @@ instance Foldable (Vector n) where
   foldr f b (Vector as) = foldr f b as
 
 instance KnownNat n => Traversable (Vector n) where
-  traverse f (Vector as) = fmap mkVector $ traverse f as
+  traverse f (Vector as) = mkVector <$> traverse f as
 
 instance Functor (Vector n) where
   fmap f (Vector as) = Vector (fmap f as)
@@ -41,7 +41,7 @@ mkVector :: forall n a. KnownNat n => [a] -> Vector n a
 mkVector as
  = let du = fromIntegral . natVal $ (undefined :: Proxy n)
        la = length as
-   in if (du == la)
+   in if du == la
         then Vector as
         else error $ "Error creating staticly sized Vector of length: " ++
                      show du ++ " list is of length:" ++ show la

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -14,6 +14,7 @@
 
 module Grenade.Layers.Convolution (
     Convolution (..)
+  , Convolution' (..)
   , randomConvolution
   , im2col
   , vid2col

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -119,15 +119,7 @@ randomConvolution = do
         mm = konst 0
     return $ Convolution wN mm
 
-instance ( Monad m
-         , KnownNat kernelRows
-         , KnownNat kernelCols
-         , KnownNat channels
-         , KnownNat filters
-         , KnownNat strideRows
-         , KnownNat strideCols
-         , kernelFlattened ~ (kernelRows * kernelColumns * channels)
-         ) => UpdateLayer m (Convolution channels filters kernelRows kernelCols strideRows strideCols) where
+instance ( Monad m ) => UpdateLayer m (Convolution channels filters kernelRows kernelCols strideRows strideCols) where
   type Gradient (Convolution channels filters kernelRows kernelCols strideRows strideCols) = (Convolution' channels filters kernelRows kernelCols strideRows strideCols)
   runUpdate LearningParameters {..} (Convolution oldKernel oldMomentum) (Convolution' kernelGradient) = do
     let newMomentum    = konst learningMomentum * oldMomentum - konst learningRate * kernelGradient

--- a/src/Grenade/Layers/Dropout.hs
+++ b/src/Grenade/Layers/Dropout.hs
@@ -9,15 +9,14 @@
 
 module Grenade.Layers.Dropout (
     Dropout (..)
+  , randomDropout
   ) where
 
 import           Control.Monad.Random hiding (fromList)
-import           Control.Monad.State
 
 import           GHC.TypeLits
 import           Grenade.Core.Shape
 import           Grenade.Core.Network
-import           Grenade.Core.Phase
 
 import           Numeric.LinearAlgebra.Static
 
@@ -27,12 +26,14 @@ import           Numeric.LinearAlgebra.Static
 -- After backpropogation, we return a new matrix/vector, with different bits dropped out.
 -- Double is the proportion to drop in each training iteration (like 1% or 5% would be
 -- reasonable).
-data Dropout o = Dropout Double (R o)
+data Dropout o =
+  Dropout (R o)
+  | Pass Double
   deriving Show
 
-instance (MonadRandom m, KnownNat i) => UpdateLayer m (Dropout i) where
+instance (KnownNat i) => UpdateLayer (Dropout i) where
   type Gradient (Dropout i) = ()
-  runUpdate _ (Dropout rate _) _ = randomDropout rate
+  runUpdate _ x _ = x
 
 randomDropout :: (MonadRandom m, KnownNat i)
               => Double -> m (Dropout i)
@@ -40,12 +41,10 @@ randomDropout rate = do
     seed  <- getRandom
     let wN = randomVector seed Uniform
         xs = dvmap (\a -> if a <= rate then 0 else 1) wN
-    return $ Dropout rate xs
+    return $ Dropout xs
 
-instance (MonadRandom m, MonadState Phase m, KnownNat i) => Layer m (Dropout i) ('D1 i) ('D1 i) where
-  runForwards (Dropout rate drops) (S1D' x) = isTrainingPhase >>= \case
-    True  -> return . S1D' $ x * drops
-    False -> return . S1D' $ dvmap (* (1 - rate)) x
-  runBackards (Dropout rate drops) _ (S1D' x) = isTrainingPhase >>= \case
-    True -> return ((),  S1D' $ x * drops)
-    False -> return ((),  S1D' $  dvmap (* (1 - rate)) x)
+instance (KnownNat i) => Layer (Dropout i) ('D1 i) ('D1 i) where
+  runForwards (Dropout drops) (S1D' x) = S1D' $ x * drops
+  runForwards (Pass rate) (S1D' x)= S1D' $ dvmap (* (1 - rate)) x
+  runBackards (Dropout drops) _ (S1D' x) = ((),  S1D' $ x * drops)
+  runBackards (Pass rate) _ (S1D' x) = ((),  S1D' $  dvmap (* (1 - rate)) x)

--- a/src/Grenade/Layers/Flatten.hs
+++ b/src/Grenade/Layers/Flatten.hs
@@ -25,20 +25,24 @@ import           Grenade.Core.Network
 data FlattenLayer = FlattenLayer
   deriving Show
 
+instance Monad m => UpdateLayer m FlattenLayer where
+  type Gradient FlattenLayer = ()
+  runUpdate _ _ _ = return FlattenLayer
+
 instance (Monad m, KnownNat a, KnownNat x, KnownNat y, a ~ (x * y)) => Layer m FlattenLayer ('D2 x y) ('D1 a) where
-  runForwards _ (S2D' y)     = return $ S1D' . fromList . toList . flatten . extract $ y
-  runBackards _ _ _ (S1D' y) = return (FlattenLayer, S2D' . fromList . toList . unwrap $ y)
+  runForwards _ (S2D' y)   = return $ S1D' . fromList . toList . flatten . extract $ y
+  runBackards _ _ (S1D' y) = return ((), S2D' . fromList . toList . unwrap $ y)
 
 instance (Monad m, KnownNat a, KnownNat x, KnownNat y, KnownNat z, a ~ (x * y * z)) => Layer m FlattenLayer ('D3 x y z) ('D1 a) where
   runForwards _ (S3D' y)     = return $ S1D' . raiseShapeError . create . vjoin . vecToList . fmap (flatten . extract) $ y
-  runBackards _ _ _ (S1D' o) = do
+  runBackards _ _ (S1D' o) = do
     let x'     = fromIntegral $ natVal (Proxy :: Proxy x)
         y'     = fromIntegral $ natVal (Proxy :: Proxy y)
         z'     = fromIntegral $ natVal (Proxy :: Proxy z)
         vecs   = takesV (replicate z' (x' * y')) (extract o)
         ls     = fmap (raiseShapeError . create . reshape y') vecs
         ls'    = mkVector ls :: Vector z (L x y)
-    return (FlattenLayer, S3D' ls')
+    return ((), S3D' ls')
 
 raiseShapeError :: Maybe a -> a
 raiseShapeError (Just x) = x

--- a/src/Grenade/Layers/Flatten.hs
+++ b/src/Grenade/Layers/Flatten.hs
@@ -25,24 +25,24 @@ import           Grenade.Core.Network
 data FlattenLayer = FlattenLayer
   deriving Show
 
-instance Monad m => UpdateLayer m FlattenLayer where
+instance UpdateLayer FlattenLayer where
   type Gradient FlattenLayer = ()
-  runUpdate _ _ _ = return FlattenLayer
+  runUpdate _ _ _ = FlattenLayer
 
-instance (Monad m, KnownNat a, KnownNat x, KnownNat y, a ~ (x * y)) => Layer m FlattenLayer ('D2 x y) ('D1 a) where
-  runForwards _ (S2D' y)   = return $ S1D' . fromList . toList . flatten . extract $ y
-  runBackards _ _ (S1D' y) = return ((), S2D' . fromList . toList . unwrap $ y)
+instance (KnownNat a, KnownNat x, KnownNat y, a ~ (x * y)) => Layer FlattenLayer ('D2 x y) ('D1 a) where
+  runForwards _ (S2D' y)   = S1D' . fromList . toList . flatten . extract $ y
+  runBackards _ _ (S1D' y) = ((), S2D' . fromList . toList . unwrap $ y)
 
-instance (Monad m, KnownNat a, KnownNat x, KnownNat y, KnownNat z, a ~ (x * y * z)) => Layer m FlattenLayer ('D3 x y z) ('D1 a) where
-  runForwards _ (S3D' y)     = return $ S1D' . raiseShapeError . create . vjoin . vecToList . fmap (flatten . extract) $ y
-  runBackards _ _ (S1D' o) = do
+instance (KnownNat a, KnownNat x, KnownNat y, KnownNat z, a ~ (x * y * z)) => Layer FlattenLayer ('D3 x y z) ('D1 a) where
+  runForwards _ (S3D' y)     = S1D' . raiseShapeError . create . vjoin . vecToList . fmap (flatten . extract) $ y
+  runBackards _ _ (S1D' o) =
     let x'     = fromIntegral $ natVal (Proxy :: Proxy x)
         y'     = fromIntegral $ natVal (Proxy :: Proxy y)
         z'     = fromIntegral $ natVal (Proxy :: Proxy z)
         vecs   = takesV (replicate z' (x' * y')) (extract o)
         ls     = fmap (raiseShapeError . create . reshape y') vecs
         ls'    = mkVector ls :: Vector z (L x y)
-    return ((), S3D' ls')
+    in ((), S3D' ls')
 
 raiseShapeError :: Maybe a -> a
 raiseShapeError (Just x) = x

--- a/src/Grenade/Layers/FullyConnected.hs
+++ b/src/Grenade/Layers/FullyConnected.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -25,25 +24,36 @@ import           Grenade.Core.Shape
 data FullyConnected i o = FullyConnected
                         !(R o)   -- Bias neuron weights
                         !(L o i) -- Activation weights
-                        !(L o i) -- Activation momentums
+                        !(L o i) -- Momentum
+
+data FullyConnected' i o = FullyConnected'
+                         !(R o)   -- Bias neuron gradient
+                         !(L o i) -- Activation gradient
 
 instance Show (FullyConnected i o) where
-  show (FullyConnected _ _ _) = "FullyConnected"
+  show FullyConnected {} = "FullyConnected"
+
+instance (Monad m, KnownNat i, KnownNat o) => UpdateLayer m (FullyConnected i o) where
+  type Gradient (FullyConnected i o) = (FullyConnected' i o)
+
+  runUpdate LearningParameters {..} (FullyConnected oldBias oldActivations oldMomentum) (FullyConnected' biasGradient activationGradient) = do
+    let newBias        = oldBias - konst learningRate * biasGradient
+        newMomentum    = konst learningMomentum * oldMomentum - konst learningRate * activationGradient
+        regulariser    = konst (learningRegulariser * learningRate) * oldActivations
+        newActivations = oldActivations + newMomentum - regulariser
+    return $ FullyConnected newBias newActivations newMomentum
 
 instance (Monad m, KnownNat i, KnownNat o) => Layer m (FullyConnected i o) ('D1 i) ('D1 o) where
   -- Do a matrix vector multiplication and return the result.
   runForwards (FullyConnected wB wN _) (S1D' v) = return $ S1D' (wB + wN #> v)
 
   -- Run a backpropogation step for a full connected layer.
-  runBackards rate (FullyConnected wB wN mm) (S1D' x) (S1D' dEdy) =
-          let wB'  = wB - konst rate * dEdy
-              mm'  = 0.9 * mm - konst rate * (dEdy `outer` x)
-              wd'  = konst (0.0001 * rate) * wN
-              wN'  = wN + mm' - wd'
-              w'   = FullyConnected wB' wN' mm'
+  runBackards (FullyConnected _ wN _) (S1D' x) (S1D' dEdy) =
+          let wB'  = dEdy
+              mm'  = dEdy `outer` x
               -- calcluate derivatives for next step
               dWs  = tr wN #> dEdy
-          in  return (w', S1D' dWs)
+          in  return (FullyConnected' wB' mm', S1D' dWs)
 
 randomFullyConnected :: (MonadRandom m, KnownNat i, KnownNat o)
                      => m (FullyConnected i o)

--- a/src/Grenade/Layers/FullyConnected.hs
+++ b/src/Grenade/Layers/FullyConnected.hs
@@ -23,6 +23,7 @@ import           Grenade.Core.Shape
 -- | A basic fully connected (or inner product) neural network layer.
 data FullyConnected i o = FullyConnected
                         !(R o)   -- Bias neuron weights
+                        !(R o)   -- Bias neuron momentum
                         !(L o i) -- Activation weights
                         !(L o i) -- Momentum
 
@@ -33,27 +34,28 @@ data FullyConnected' i o = FullyConnected'
 instance Show (FullyConnected i o) where
   show FullyConnected {} = "FullyConnected"
 
-instance (Monad m, KnownNat i, KnownNat o) => UpdateLayer m (FullyConnected i o) where
+instance (KnownNat i, KnownNat o) => UpdateLayer (FullyConnected i o) where
   type Gradient (FullyConnected i o) = (FullyConnected' i o)
 
-  runUpdate LearningParameters {..} (FullyConnected oldBias oldActivations oldMomentum) (FullyConnected' biasGradient activationGradient) = do
-    let newBias        = oldBias - konst learningRate * biasGradient
-        newMomentum    = konst learningMomentum * oldMomentum - konst learningRate * activationGradient
-        regulariser    = konst (learningRegulariser * learningRate) * oldActivations
-        newActivations = oldActivations + newMomentum - regulariser
-    return $ FullyConnected newBias newActivations newMomentum
+  runUpdate LearningParameters {..} (FullyConnected oldBias oldBiasMomentum oldActivations oldMomentum) (FullyConnected' biasGradient activationGradient) =
+    let newBiasMomentum = konst learningMomentum * oldBiasMomentum - konst learningRate * biasGradient
+        newBias         = oldBias + newBiasMomentum
+        newMomentum     = konst learningMomentum * oldMomentum - konst learningRate * activationGradient
+        regulariser     = konst (learningRegulariser * learningRate) * oldActivations
+        newActivations  = oldActivations + newMomentum - regulariser
+    in FullyConnected newBias newBiasMomentum newActivations newMomentum
 
-instance (Monad m, KnownNat i, KnownNat o) => Layer m (FullyConnected i o) ('D1 i) ('D1 o) where
+instance (KnownNat i, KnownNat o) => Layer (FullyConnected i o) ('D1 i) ('D1 o) where
   -- Do a matrix vector multiplication and return the result.
-  runForwards (FullyConnected wB wN _) (S1D' v) = return $ S1D' (wB + wN #> v)
+  runForwards (FullyConnected wB _ wN _) (S1D' v) = S1D' (wB + wN #> v)
 
   -- Run a backpropogation step for a full connected layer.
-  runBackards (FullyConnected _ wN _) (S1D' x) (S1D' dEdy) =
+  runBackards (FullyConnected _ _ wN _) (S1D' x) (S1D' dEdy) =
           let wB'  = dEdy
               mm'  = dEdy `outer` x
               -- calcluate derivatives for next step
               dWs  = tr wN #> dEdy
-          in  return (FullyConnected' wB' mm', S1D' dWs)
+          in  (FullyConnected' wB' mm', S1D' dWs)
 
 randomFullyConnected :: (MonadRandom m, KnownNat i, KnownNat o)
                      => m (FullyConnected i o)
@@ -62,5 +64,6 @@ randomFullyConnected = do
     s2 :: Int <- getRandom
     let wB = randomVector  s1 Uniform * 2 - 1
         wN = uniformSample s2 (-1) 1
+        bm = konst 0
         mm = konst 0
-    return $ FullyConnected wB wN mm
+    return $ FullyConnected wB bm wN mm

--- a/src/Grenade/Layers/Logit.hs
+++ b/src/Grenade/Layers/Logit.hs
@@ -22,21 +22,21 @@ import           Grenade.Core.Shape
 data Logit = Logit
   deriving Show
 
-instance Monad m => UpdateLayer m Logit where
+instance UpdateLayer Logit where
   type Gradient Logit = ()
-  runUpdate _ _ _ = return Logit
+  runUpdate _ _ _ = Logit
 
-instance (Monad m, KnownNat i) => Layer m Logit ('D1 i) ('D1 i) where
-  runForwards _ (S1D' y) = return $ S1D' (logistic y)
-  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (logistic' y * dEdy))
+instance (KnownNat i) => Layer Logit ('D1 i) ('D1 i) where
+  runForwards _ (S1D' y) = S1D' (logistic y)
+  runBackards _ (S1D' y) (S1D' dEdy) = ((), S1D' (logistic' y * dEdy))
 
-instance (Monad m, KnownNat i, KnownNat j) => Layer m Logit ('D2 i j) ('D2 i j) where
-  runForwards _ (S2D' y) = return $ S2D' (logistic y)
-  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (logistic' y * dEdy))
+instance (KnownNat i, KnownNat j) => Layer Logit ('D2 i j) ('D2 i j) where
+  runForwards _ (S2D' y) = S2D' (logistic y)
+  runBackards _ (S2D' y) (S2D' dEdy) = ((), S2D' (logistic' y * dEdy))
 
-instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Logit ('D3 i j k) ('D3 i j k) where
-  runForwards _ (S3D' y) = return $ S3D' (fmap logistic y)
-  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> logistic' y' * dEdy') y dEdy))
+instance (KnownNat i, KnownNat j, KnownNat k) => Layer Logit ('D3 i j k) ('D3 i j k) where
+  runForwards _ (S3D' y) =  S3D' (fmap logistic y)
+  runBackards _ (S3D' y) (S3D' dEdy) = ((), S3D' (vectorZip (\y' dEdy' -> logistic' y' * dEdy') y dEdy))
 
 
 logistic :: Floating a => a -> a

--- a/src/Grenade/Layers/Logit.hs
+++ b/src/Grenade/Layers/Logit.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -10,6 +8,7 @@
 module Grenade.Layers.Logit (
     Logit (..)
   ) where
+
 
 import           Data.Singletons.TypeLits
 import           Grenade.Core.Network
@@ -23,17 +22,21 @@ import           Grenade.Core.Shape
 data Logit = Logit
   deriving Show
 
+instance Monad m => UpdateLayer m Logit where
+  type Gradient Logit = ()
+  runUpdate _ _ _ = return Logit
+
 instance (Monad m, KnownNat i) => Layer m Logit ('D1 i) ('D1 i) where
   runForwards _ (S1D' y) = return $ S1D' (logistic y)
-  runBackards _ _ (S1D' y) (S1D' dEdy) = return (Logit, S1D' (logistic' y * dEdy))
+  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (logistic' y * dEdy))
 
 instance (Monad m, KnownNat i, KnownNat j) => Layer m Logit ('D2 i j) ('D2 i j) where
   runForwards _ (S2D' y) = return $ S2D' (logistic y)
-  runBackards _ _ (S2D' y) (S2D' dEdy) = return (Logit, S2D' (logistic' y * dEdy))
+  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (logistic' y * dEdy))
 
 instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Logit ('D3 i j k) ('D3 i j k) where
   runForwards _ (S3D' y) = return $ S3D' (fmap logistic y)
-  runBackards _ _ (S3D' y) (S3D' dEdy) = return (Logit, S3D' (vectorZip (\y' dEdy' -> logistic' y' * dEdy') y dEdy))
+  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> logistic' y' * dEdy') y dEdy))
 
 
 logistic :: Floating a => a -> a

--- a/src/Grenade/Layers/Pooling.hs
+++ b/src/Grenade/Layers/Pooling.hs
@@ -51,13 +51,12 @@ instance Show (Pooling k k' s s') where
   show Pooling = "Pooling"
 
 
-instance Monad m => UpdateLayer m (Pooling kernelRows kernelColumns strideRows strideColumns) where
+instance UpdateLayer (Pooling kernelRows kernelColumns strideRows strideColumns) where
   type Gradient (Pooling kr kc sr sc) = ()
-  runUpdate _ Pooling _ = return Pooling
+  runUpdate _ Pooling _ = Pooling
 
 -- | A two dimentional image can be pooled.
-instance ( Monad m
-         , KnownNat kernelRows
+instance ( KnownNat kernelRows
          , KnownNat kernelColumns
          , KnownNat strideRows
          , KnownNat strideColumns
@@ -67,7 +66,7 @@ instance ( Monad m
          , KnownNat outputColumns
          , ((outputRows - 1) * strideRows) ~ (inputRows - kernelRows)
          , ((outputColumns - 1) * strideColumns) ~ (inputColumns - kernelColumns)
-         ) => Layer m (Pooling kernelRows kernelColumns strideRows strideColumns) ('D2 inputRows inputColumns) ('D2 outputRows outputColumns) where
+         ) => Layer (Pooling kernelRows kernelColumns strideRows strideColumns) ('D2 inputRows inputColumns) ('D2 outputRows outputColumns) where
   runForwards Pooling (S2D' input) =
     let kx = fromIntegral $ natVal (Proxy :: Proxy kernelRows)
         ky = fromIntegral $ natVal (Proxy :: Proxy kernelColumns)
@@ -78,7 +77,7 @@ instance ( Monad m
         ex = extract input
         r  = poolForward kx ky sx sy ox oy $ ex
         rs = fromJust . create $ r
-    in  return . S2D' $ rs
+    in  S2D' $ rs
   runBackards Pooling (S2D' input) (S2D' dEdy) =
     let kx = fromIntegral $ natVal (Proxy :: Proxy kernelRows)
         ky = fromIntegral $ natVal (Proxy :: Proxy kernelColumns)
@@ -87,12 +86,11 @@ instance ( Monad m
         ex = extract input
         eo = extract dEdy
         vs = poolBackward kx ky sx sy ex eo
-    in  return ((), S2D' . fromJust . create $ vs)
+    in  ((), S2D' . fromJust . create $ vs)
 
 
 -- | A three dimensional image can be pooled on each layer.
-instance ( Monad m
-         , KnownNat kernelRows
+instance ( KnownNat kernelRows
          , KnownNat kernelColumns
          , KnownNat strideRows
          , KnownNat strideColumns
@@ -102,7 +100,7 @@ instance ( Monad m
          , KnownNat outputColumns
          , ((outputRows - 1) * strideRows) ~ (inputRows - kernelRows)
          , ((outputColumns - 1) * strideColumns) ~ (inputColumns - kernelColumns)
-         ) => Layer m (Pooling kernelRows kernelColumns strideRows strideColumns) ('D3 inputRows inputColumns channels) ('D3 outputRows outputColumns channels) where
+         ) => Layer (Pooling kernelRows kernelColumns strideRows strideColumns) ('D3 inputRows inputColumns channels) ('D3 outputRows outputColumns channels) where
   runForwards Pooling (S3D' input) =
     let ix = fromIntegral $ natVal (Proxy :: Proxy inputRows)
         iy = fromIntegral $ natVal (Proxy :: Proxy inputColumns)
@@ -115,7 +113,7 @@ instance ( Monad m
         ex = fmap extract input
         r  = poolForwardList kx ky sx sy ix iy ox oy ex
         rs = fmap (fromJust . create) r
-    in  return . S3D' $ rs
+    in  S3D' rs
   runBackards Pooling (S3D' input) (S3D' dEdy) =
     let ix = fromIntegral $ natVal (Proxy :: Proxy inputRows)
         iy = fromIntegral $ natVal (Proxy :: Proxy inputColumns)
@@ -127,7 +125,7 @@ instance ( Monad m
         eo = fmap extract dEdy
         ez = vectorZip (,) ex eo
         vs = poolBackwardList kx ky sx sy ix iy ez
-    in  return ((), S3D' . fmap (fromJust . create) $ vs)
+    in  ((), S3D' . fmap (fromJust . create) $ vs)
 
 poolForward :: Int -> Int -> Int -> Int -> Int -> Int -> Matrix Double -> Matrix Double
 poolForward nrows ncols srows scols outputRows outputCols m =

--- a/src/Grenade/Layers/Relu.hs
+++ b/src/Grenade/Layers/Relu.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -24,11 +22,15 @@ import qualified Numeric.LinearAlgebra.Static as LAS
 data Relu = Relu
   deriving Show
 
+instance Monad m => UpdateLayer m Relu where
+  type Gradient Relu = ()
+  runUpdate _ _ _ = return Relu
+
 instance (Monad m, KnownNat i) => Layer m Relu ('D1 i) ('D1 i) where
   runForwards _ (S1D' y) = return $ S1D' (relu y)
     where
       relu = LAS.dvmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ _ (S1D' y) (S1D' dEdy) = return (Relu, S1D' (relu' y * dEdy))
+  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (relu' y * dEdy))
     where
       relu' = LAS.dvmap (\a -> if a <= 0 then 0 else 1)
 
@@ -36,7 +38,7 @@ instance (Monad m, KnownNat i, KnownNat j) => Layer m Relu ('D2 i j) ('D2 i j) w
   runForwards _ (S2D' y) = return $ S2D' (relu y)
     where
       relu = LAS.dmmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ _ (S2D' y) (S2D' dEdy) = return (Relu, S2D' (relu' y * dEdy))
+  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (relu' y * dEdy))
     where
       relu' = LAS.dmmap (\a -> if a <= 0 then 0 else 1)
 
@@ -44,6 +46,6 @@ instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Relu ('D3 i j 
   runForwards _ (S3D' y) = return $ S3D' (fmap relu y)
     where
       relu = LAS.dmmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ _ (S3D' y) (S3D' dEdy) = return (Relu, S3D' (vectorZip (\y' dEdy' -> relu' y' * dEdy') y dEdy))
+  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> relu' y' * dEdy') y dEdy))
     where
       relu' = LAS.dmmap (\a -> if a <= 0 then 0 else 1)

--- a/src/Grenade/Layers/Relu.hs
+++ b/src/Grenade/Layers/Relu.hs
@@ -22,30 +22,30 @@ import qualified Numeric.LinearAlgebra.Static as LAS
 data Relu = Relu
   deriving Show
 
-instance Monad m => UpdateLayer m Relu where
+instance UpdateLayer Relu where
   type Gradient Relu = ()
-  runUpdate _ _ _ = return Relu
+  runUpdate _ _ _ = Relu
 
-instance (Monad m, KnownNat i) => Layer m Relu ('D1 i) ('D1 i) where
-  runForwards _ (S1D' y) = return $ S1D' (relu y)
+instance ( KnownNat i) => Layer Relu ('D1 i) ('D1 i) where
+  runForwards _ (S1D' y) = S1D' (relu y)
     where
       relu = LAS.dvmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (relu' y * dEdy))
+  runBackards _ (S1D' y) (S1D' dEdy) = ((), S1D' (relu' y * dEdy))
     where
       relu' = LAS.dvmap (\a -> if a <= 0 then 0 else 1)
 
-instance (Monad m, KnownNat i, KnownNat j) => Layer m Relu ('D2 i j) ('D2 i j) where
-  runForwards _ (S2D' y) = return $ S2D' (relu y)
+instance (KnownNat i, KnownNat j) => Layer Relu ('D2 i j) ('D2 i j) where
+  runForwards _ (S2D' y) = S2D' (relu y)
     where
       relu = LAS.dmmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (relu' y * dEdy))
+  runBackards _ (S2D' y) (S2D' dEdy) = ((), S2D' (relu' y * dEdy))
     where
       relu' = LAS.dmmap (\a -> if a <= 0 then 0 else 1)
 
-instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Relu ('D3 i j k) ('D3 i j k) where
-  runForwards _ (S3D' y) = return $ S3D' (fmap relu y)
+instance (KnownNat i, KnownNat j, KnownNat k) => Layer Relu ('D3 i j k) ('D3 i j k) where
+  runForwards _ (S3D' y) = S3D' (fmap relu y)
     where
       relu = LAS.dmmap (\a -> if a <= 0 then 0 else a)
-  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> relu' y' * dEdy') y dEdy))
+  runBackards _ (S3D' y) (S3D' dEdy) = ((), S3D' (vectorZip (\y' dEdy' -> relu' y' * dEdy') y dEdy))
     where
       relu' = LAS.dmmap (\a -> if a <= 0 then 0 else 1)

--- a/src/Grenade/Layers/Tanh.hs
+++ b/src/Grenade/Layers/Tanh.hs
@@ -19,21 +19,21 @@ import           Grenade.Core.Shape
 data Tanh = Tanh
   deriving Show
 
-instance Monad m => UpdateLayer m Tanh where
+instance UpdateLayer Tanh where
   type Gradient Tanh = ()
-  runUpdate _ _ _ = return Tanh
+  runUpdate _ _ _ = Tanh
 
-instance (Monad m, KnownNat i) => Layer m Tanh ('D1 i) ('D1 i) where
-  runForwards _ (S1D' y) = return $ S1D' (tanh y)
-  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (tanh' y * dEdy))
+instance KnownNat i => Layer Tanh ('D1 i) ('D1 i) where
+  runForwards _ (S1D' y) = S1D' (tanh y)
+  runBackards _ (S1D' y) (S1D' dEdy) = ((), S1D' (tanh' y * dEdy))
 
-instance (Monad m, KnownNat i, KnownNat j) => Layer m Tanh ('D2 i j) ('D2 i j) where
-  runForwards _ (S2D' y) = return $ S2D' (tanh y)
-  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (tanh' y * dEdy))
+instance (KnownNat i, KnownNat j) => Layer Tanh ('D2 i j) ('D2 i j) where
+  runForwards _ (S2D' y) =  S2D' (tanh y)
+  runBackards _ (S2D' y) (S2D' dEdy) = ((), S2D' (tanh' y * dEdy))
 
-instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Tanh ('D3 i j k) ('D3 i j k) where
-  runForwards _ (S3D' y) = return $ S3D' (fmap tanh y)
-  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> tanh' y' * dEdy') y dEdy))
+instance (KnownNat i, KnownNat j, KnownNat k) => Layer Tanh ('D3 i j k) ('D3 i j k) where
+  runForwards _ (S3D' y) = S3D' (fmap tanh y)
+  runBackards _ (S3D' y) (S3D' dEdy) = ((), S3D' (vectorZip (\y' dEdy' -> tanh' y' * dEdy') y dEdy))
 
 tanh' :: (Floating a) => a -> a
 tanh' t = 1 - s ^ (2 :: Int)  where s = tanh t

--- a/src/Grenade/Layers/Tanh.hs
+++ b/src/Grenade/Layers/Tanh.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -21,17 +19,21 @@ import           Grenade.Core.Shape
 data Tanh = Tanh
   deriving Show
 
+instance Monad m => UpdateLayer m Tanh where
+  type Gradient Tanh = ()
+  runUpdate _ _ _ = return Tanh
+
 instance (Monad m, KnownNat i) => Layer m Tanh ('D1 i) ('D1 i) where
   runForwards _ (S1D' y) = return $ S1D' (tanh y)
-  runBackards _ _ (S1D' y) (S1D' dEdy) = return (Tanh, S1D' (tanh' y * dEdy))
+  runBackards _ (S1D' y) (S1D' dEdy) = return ((), S1D' (tanh' y * dEdy))
 
 instance (Monad m, KnownNat i, KnownNat j) => Layer m Tanh ('D2 i j) ('D2 i j) where
   runForwards _ (S2D' y) = return $ S2D' (tanh y)
-  runBackards _ _ (S2D' y) (S2D' dEdy) = return (Tanh, S2D' (tanh' y * dEdy))
+  runBackards _ (S2D' y) (S2D' dEdy) = return ((), S2D' (tanh' y * dEdy))
 
 instance (Monad m, KnownNat i, KnownNat j, KnownNat k) => Layer m Tanh ('D3 i j k) ('D3 i j k) where
   runForwards _ (S3D' y) = return $ S3D' (fmap tanh y)
-  runBackards _ _ (S3D' y) (S3D' dEdy) = return (Tanh, S3D' (vectorZip (\y' dEdy' -> tanh' y' * dEdy') y dEdy))
+  runBackards _ (S3D' y) (S3D' dEdy) = return ((), S3D' (vectorZip (\y' dEdy' -> tanh' y' * dEdy') y dEdy))
 
 tanh' :: (Floating a) => a -> a
 tanh' t = 1 - s ^ (2 :: Int)  where s = tanh t

--- a/test/Test/Grenade/Layers/Convolution.hs
+++ b/test/Test/Grenade/Layers/Convolution.hs
@@ -4,8 +4,6 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Test.Grenade.Layers.Convolution where
 
-import           Control.Monad.Identity
-
 import           Grenade.Core.Shape
 import           Grenade.Core.Vector as Grenade
 import           Grenade.Core.Network
@@ -114,7 +112,7 @@ prop_simple_conv_forwards = once $
                  [  5.0 ,  9.0  ] :: HStatic.L 1 2)
                ,(HStatic.matrix
                  [ -7.0 , -10.0 ] :: HStatic.L 1 2)]) :: [HStatic.L 1 2]
-      out  = runIdentity $ runForwards convLayer input :: S' ('D3 1 2 4)
+      out  = runForwards convLayer input :: S' ('D3 1 2 4)
 
       grad =  S3D' ( mkVector
                [(HStatic.matrix
@@ -129,7 +127,7 @@ prop_simple_conv_forwards = once $
       expectBack = (HStatic.matrix
                    [  1.0,  0.0, 0.0
                    ,  0.0, -2.0,-1.0] :: HStatic.L 2 3)
-      (nc, inX)  = runIdentity $ runBackards convLayer input grad
+      (nc, inX)  =  runBackards convLayer input grad
 
   in case (out, inX, nc) of
     (S3D' out' , S2D' inX', Convolution' backGrad)
@@ -226,7 +224,7 @@ prop_single_conv_forwards = once $
                  [  5.0 ,  9.0  ] :: HStatic.L 1 2)
                ,(HStatic.matrix
                  [ -7.0 , -10.0 ] :: HStatic.L 1 2)]) :: [HStatic.L 1 2]
-      out  = runIdentity $ runForwards convLayer input :: S' ('D3 1 2 4)
+      out  = runForwards convLayer input :: S' ('D3 1 2 4)
 
       grad =  S3D' ( mkVector
                [(HStatic.matrix
@@ -241,7 +239,7 @@ prop_single_conv_forwards = once $
       expectBack = (HStatic.matrix
                    [  1.0,  0.0, 0.0
                    ,  0.0, -2.0,-1.0] :: HStatic.L 2 3)
-      (nc, inX)  = runIdentity $ runBackards convLayer input grad
+      (nc, inX)  = runBackards convLayer input grad
 
   in case (out, inX, nc) of
     (S3D' out' , S3D' inX', Convolution' backGrad)

--- a/test/Test/Grenade/Layers/Convolution.hs
+++ b/test/Test/Grenade/Layers/Convolution.hs
@@ -93,11 +93,12 @@ prop_simple_conv_forwards = once $
                  , 0.0,  0.0,  0.0,  0.0
                  , 0.0,  0.0,  0.0,  0.0
                  , 0.0,  0.0,  0.0,  0.0 ] :: HStatic.L 4 4)
-      --expectedKernel = (HStatic.matrix
-      --           [ 0.0,  0.0,  0.0, -2.0
-      --           ,-2.0,  1.0,  1.0, -5.0
-      --           ,-3.0, -1.0,  1.0, -5.0
-      --           ,-5.0,  0.0,  0.0, -7.0 ] :: HStatic.L 4 4)
+
+      expectedGradient = (HStatic.matrix
+                 [ 1.0, 0.0, 0.0, 2.0
+                 , 2.0, 0.0, 0.0, 5.0
+                 , 3.0, 0.0, 0.0, 4.0
+                 , 4.0, 0.0, 0.0, 6.0 ] :: HStatic.L 4 4)
 
       convLayer = Convolution myKernel zeroKernel :: Convolution 1 4 2 2 1 1
 
@@ -128,12 +129,13 @@ prop_simple_conv_forwards = once $
       expectBack = (HStatic.matrix
                    [  1.0,  0.0, 0.0
                    ,  0.0, -2.0,-1.0] :: HStatic.L 2 3)
-      (nc, inX)  = runIdentity $ runBackards 1 convLayer input grad :: ( Convolution 1 4 2 2 1 1 ,  S' ('D2 2 3))
+      (nc, inX)  = runIdentity $ runBackards convLayer input grad
 
   in case (out, inX, nc) of
-    (S3D' out' , S2D' inX', Convolution _ _)
+    (S3D' out' , S2D' inX', Convolution' backGrad)
       -> ((HStatic.extract <$> expect) === (HStatic.extract <$> vecToList out'))
       .&&. ((HStatic.extract expectBack) === (HStatic.extract inX'))
+      .&&. ((HStatic.extract expectedGradient) === (HStatic.extract backGrad))
       -- Temporarily disabled, as l2 adjustment puts in off 5%
       -- .&&. HStatic.extract expectedKernel === HStatic.extract kernel'
 
@@ -203,11 +205,12 @@ prop_single_conv_forwards = once $
                  , 0.0,  0.0,  0.0,  0.0
                  , 0.0,  0.0,  0.0,  0.0
                  , 0.0,  0.0,  0.0,  0.0 ] :: HStatic.L 4 4)
-      --expectedKernel = (HStatic.matrix
-      --           [ 0.0,  0.0,  0.0, -2.0
-      --           ,-2.0,  1.0,  1.0, -5.0
-      --           ,-3.0, -1.0,  1.0, -5.0
-      --           ,-5.0,  0.0,  0.0, -7.0 ] :: HStatic.L 4 4)
+
+      expectedGradient = (HStatic.matrix
+                 [ 1.0, 0.0, 0.0, 2.0
+                 , 2.0, 0.0, 0.0, 5.0
+                 , 3.0, 0.0, 0.0, 4.0
+                 , 4.0, 0.0, 0.0, 6.0 ] :: HStatic.L 4 4)
 
       convLayer = Convolution myKernel zeroKernel :: Convolution 1 4 2 2 1 1
 
@@ -238,13 +241,13 @@ prop_single_conv_forwards = once $
       expectBack = (HStatic.matrix
                    [  1.0,  0.0, 0.0
                    ,  0.0, -2.0,-1.0] :: HStatic.L 2 3)
-      (nc, inX)  = runIdentity $ runBackards 1 convLayer input grad :: ( Convolution 1 4 2 2 1 1 ,  S' ('D3 2 3 1))
+      (nc, inX)  = runIdentity $ runBackards convLayer input grad
 
   in case (out, inX, nc) of
-    (S3D' out' , S3D' inX', Convolution _ _)
+    (S3D' out' , S3D' inX', Convolution' backGrad)
       ->   ((HStatic.extract <$> expect)  === (HStatic.extract <$> vecToList out'))
       .&&. ([HStatic.extract expectBack]  === (HStatic.extract <$> vecToList inX'))
-      -- .&&. HStatic.extract expectedKernel === HStatic.extract kernel'
+      .&&. ((HStatic.extract expectedGradient) === (HStatic.extract backGrad))
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
Goal here is to take learning out of back prop. Interestingly, I'm now returning a Gradient type from runBackwards, which is often `()` for layers like logit and tanh.

This means we don't have to shuffle around multiple sets of momentums, there can be just one in the layer.

Step one in getting it ready for parallel execution.