### PR TITLE
Fix off-by-one error in C code

### DIFF
--- a/cbits/gradient_decent.c
+++ b/cbits/gradient_decent.c
@@ -6,7 +6,7 @@ void decend_cpu(int len, double rate, double momentum, double regulariser,
     const double* last,
     double* outputWeights, double* outputMomentum) {
 
-  for (int i = 0; i <= len; i++) {
+  for (int i = 0; i < len; i++) {
       outputMomentum[i] = momentum * last[i] - rate * gradient[i];
       outputWeights[i] = weights[i] + outputMomentum[i] - (rate * regulariser) * weights[i];
   }


### PR DESCRIPTION
Noticed there was some C code, had a look an noticed an off by one error. If `len` is an actual length and the first index is `0` then all indices should be `< len`.
