### PR TITLE
Optimise Wengert tape for LSTM

### DIFF
--- a/bench/bench-lstm.hs
+++ b/bench/bench-lstm.hs
@@ -5,60 +5,21 @@ import Criterion.Main
 
 import           Grenade
 import           Grenade.Recurrent
-import           Grenade.Layers.Internal.Update
-
-import qualified Numeric.LinearAlgebra.Static as H
 
 main :: IO ()
 main = do
-  layer60  :: LSTM 40 60  <- createRandom
-  layer512 :: LSTM 40 512 <- createRandom
   input40  :: S ('D1 40)  <- randomOfShape
-  rec60    :: S ('D1 60)  <- randomOfShape
-  rec512   :: S ('D1 512) <- randomOfShape
   lstm     :: RecNet      <- randomRecurrent
 
-  let upIn60   :: H.R 3600    = H.randomVector 1 H.Uniform * 2 - 1
-  let upIn512  :: H.R 262144  = H.randomVector 1 H.Uniform * 2 - 1
-
   defaultMain [
-      bgroup "lstm"   [ bench "forwards-60"       $ nf (nfT3 . uncurry  (testRun60   layer60))  (rec60, input40)
-                      , bench "forwards-512"      $ nf (nfT3 . uncurry  (testRun512  layer512)) (rec512, input40)
-                      , bench "backwards-60"      $ nf (nfT3 . uncurry4 (testRun60'  layer60))  (rec60, input40, rec60, rec60)
-                      , bench "backwards-512"     $ nf (nfT3 . uncurry4 (testRun512' layer512)) (rec512, input40, rec512, rec512)
-                      ]
-    , bgroup "update" [ bench "matrix-60x60"      $ nf (uncurry3 (descendVector 1 1 1)) (upIn60, upIn60, upIn60)
-                      , bench "matrix-512x512"    $ nf (uncurry3 (descendVector 1 1 1)) (upIn512, upIn512, upIn512)
-                      ]
-    , bgroup "train"  [ bench "one-time-step"     $ whnf (nfT2 . trainRecurrent lp lstm 0) [(input40, Just input40)]
+      bgroup "train"  [ bench "one-time-step"     $ whnf (nfT2 . trainRecurrent lp lstm 0) [(input40, Just input40)]
                       , bench "ten-time-steps"    $ whnf (nfT2 . trainRecurrent lp lstm 0) $ replicate 10 (input40, Just input40)
                       , bench "fifty-time-steps"  $ whnf (nfT2 . trainRecurrent lp lstm 0) $ replicate 50 (input40, Just input40)
                       ]
     ]
 
-testRun60 :: LSTM 40 60 -> S ('D1 60) -> S ('D1 40) -> ((S ('D1 60), S ('D1 40)), S ('D1 60), S ('D1 60))
-testRun60 = runRecurrentForwards
-
-testRun60' :: LSTM 40 60 -> S ('D1 60) -> S ('D1 40) -> S ('D1 60) -> S ('D1 60) -> (Gradient (LSTM 40 60), S ('D1 60), S ('D1 40))
-testRun60' = curry . runRecurrentBackwards
-
-testRun512 :: LSTM 40 512 -> S ('D1 512) -> S ('D1 40) -> ((S ('D1 512), S ('D1 40)), S ('D1 512), S ('D1 512))
-testRun512 = runRecurrentForwards
-
-testRun512' :: LSTM 40 512 -> S ('D1 512) -> S ('D1 40) -> S ('D1 512) -> S ('D1 512) -> (Gradient (LSTM 40 512), S ('D1 512), S ('D1 40))
-testRun512' = curry . runRecurrentBackwards
-
-uncurry4 :: (t -> t1 -> t2 -> t3 -> t4) -> (t, t1, t2, t3) -> t4
-uncurry4 f (a,b,c,d) = f a b c d
-
-uncurry3 :: (t -> t1 -> t2 -> t3) -> (t, t1, t2) -> t3
-uncurry3 f (a,b,c) = f a b c
-
 nfT2 :: (a, b) -> (a, b)
 nfT2 (!a, !b) = (a, b)
-
-nfT3 :: (a, b, c) -> (b, c)
-nfT3 (!_, !b, !c) = (b, c)
 
 
 type R = Recurrent

--- a/src/Grenade/Layers/Elu.hs
+++ b/src/Grenade/Layers/Elu.hs
@@ -36,12 +36,12 @@ instance Serialize Elu where
   get = return Elu
 
 instance ( KnownNat i) => Layer Elu ('D1 i) ('D1 i) where
-  type Tape Elu ('D1 i) ('D1 i) = S ('D1 i)
+  type Tape Elu ('D1 i) ('D1 i) = LAS.R i
 
-  runForwards _ (S1D y) = (S1D y, S1D (elu y))
+  runForwards _ (S1D y) = (y, S1D (elu y))
     where
       elu = LAS.dvmap (\a -> if a <= 0 then exp a - 1 else a)
-  runBackwards _ (S1D y) (S1D dEdy) = ((), S1D (elu' y * dEdy))
+  runBackwards _ y (S1D dEdy) = ((), S1D (elu' y * dEdy))
     where
       elu' = LAS.dvmap (\a -> if a <= 0 then exp a else 1)
 

--- a/src/Grenade/Layers/FullyConnected.hs
+++ b/src/Grenade/Layers/FullyConnected.hs
@@ -46,12 +46,12 @@ instance (KnownNat i, KnownNat o) => UpdateLayer (FullyConnected i o) where
   createRandom = randomFullyConnected
 
 instance (KnownNat i, KnownNat o) => Layer (FullyConnected i o) ('D1 i) ('D1 o) where
-  type Tape (FullyConnected i o) ('D1 i) ('D1 o) = S ('D1 i)
+  type Tape (FullyConnected i o) ('D1 i) ('D1 o) = R i
   -- Do a matrix vector multiplication and return the result.
-  runForwards (FullyConnected (FullyConnected' wB wN) _) (S1D v) = (S1D v, S1D (wB + wN #> v))
+  runForwards (FullyConnected (FullyConnected' wB wN) _) (S1D v) = (v, S1D (wB + wN #> v))
 
   -- Run a backpropogation step for a full connected layer.
-  runBackwards (FullyConnected (FullyConnected' _ wN) _) (S1D x) (S1D dEdy) =
+  runBackwards (FullyConnected (FullyConnected' _ wN) _) x (S1D dEdy) =
           let wB'  = dEdy
               mm'  = dEdy `outer` x
               -- calcluate derivatives for next step

--- a/test/Test/Grenade/Recurrent/Layers/LSTM.hs
+++ b/test/Test/Grenade/Recurrent/Layers/LSTM.hs
@@ -65,7 +65,9 @@ prop_lstm_reference_backwards =
     input :: S.R 3                       <- forAll randomVector
     cell :: S.R 2                        <- forAll randomVector
     net@(LSTM lstmWeights _) :: LSTM 3 2 <- forAll genLSTM
-    let actualBacks     = runRecurrentBackwards net (S1D cell, S1D input) (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
+    let (tape, _ :: S ('D1 2), _ :: S ('D1 2))
+                                          = runRecurrentForwards  net (S1D cell) (S1D input)
+        actualBacks                       = runRecurrentBackwards net tape (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
     case actualBacks of
       (actualGradients, _, _ :: S ('D1 3)) ->
         let refNet          = Reference.lstmToReference lstmWeights
@@ -79,7 +81,9 @@ prop_lstm_reference_backwards_input =
     input :: S.R 3                       <- forAll randomVector
     cell :: S.R 2                        <- forAll randomVector
     net@(LSTM lstmWeights _) :: LSTM 3 2 <- forAll genLSTM
-    let actualBacks     = runRecurrentBackwards net (S1D cell, S1D input) (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
+    let (tape, _ :: S ('D1 2), _ :: S ('D1 2))
+                                          = runRecurrentForwards  net (S1D cell) (S1D input)
+        actualBacks                       = runRecurrentBackwards net tape (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
     case actualBacks of
       (_, _, S1D actualGradients :: S ('D1 3)) ->
         let refNet          = Reference.lstmToReference lstmWeights
@@ -93,7 +97,9 @@ prop_lstm_reference_backwards_cell =
     input :: S.R 3                       <- forAll randomVector
     cell :: S.R 2                        <- forAll randomVector
     net@(LSTM lstmWeights _) :: LSTM 3 2 <- forAll genLSTM
-    let actualBacks     = runRecurrentBackwards net (S1D cell, S1D input) (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
+    let (tape, _ :: S ('D1 2), _ :: S ('D1 2))
+                                          = runRecurrentForwards  net (S1D cell) (S1D input)
+        actualBacks                       = runRecurrentBackwards net tape (S1D (S.konst 1) :: S ('D1 2)) (S1D (S.konst 1) :: S ('D1 2))
     case actualBacks of
       (_, S1D actualGradients, _ :: S ('D1 3)) ->
         let refNet          = Reference.lstmToReference lstmWeights


### PR DESCRIPTION
Unfortunately my tests and benchmarks were not opaque to the tape type. Looks like this gives a 10-25% speed up for LSTM calculations, which is ok.

I've also removed a few unnecessary `S` constructors.