### PR TITLE
Added types Accuracy and HyperParamAccuracy

### DIFF
--- a/grenade.cabal
+++ b/grenade.cabal
@@ -43,6 +43,7 @@ library
                      , containers                      >= 0.5         && < 0.6
                      , cereal                          >= 0.5         && < 0.6
                      , deepseq                         >= 1.4         && < 1.5
+                     , exceptions
                      , hmatrix                         == 0.18.*
                      , MonadRandom                     >= 0.4         && < 0.6
                      , primitive                       >= 0.6         && < 0.7
@@ -106,6 +107,8 @@ library
                        Grenade.Recurrent.Layers.LSTM
 
                        Grenade.Utils.OneHot
+                       Grenade.Utils.Accuracy
+                       Grenade.Utils.Accuracy.Internal
 
   includes:            cbits/im2col.h
                        cbits/gradient_descent.h

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -37,7 +37,8 @@ source-repository head
 
 library
   build-depends:
-                       base                            >= 4.8         && < 5
+                       aeson
+                     , base                            >= 4.8         && < 5
                      , bytestring                      == 0.10.*
                      , containers                      >= 0.5         && < 0.6
                      , cereal                          >= 0.5         && < 0.6
@@ -46,6 +47,7 @@ library
                      , MonadRandom                     >= 0.4         && < 0.6
                      , primitive                       >= 0.6         && < 0.7
                      , singletons                      >= 2.1         && < 2.4
+                     , validity                        >= 0.4.0.4     && < 5.0
                      , vector                          >= 0.11        && < 0.13
 
   ghc-options:
@@ -130,6 +132,8 @@ test-suite test
                        Test.Hedgehog.TypeLits
 
                        Test.Grenade.Network
+                       Test.Grenade.Gen
+                       Test.Grenade.InstanceSpec
                        Test.Grenade.Layers.Convolution
                        Test.Grenade.Layers.FullyConnected
                        Test.Grenade.Layers.Nonlinear
@@ -148,6 +152,9 @@ test-suite test
   build-depends:
                        base                            >= 4.8         && < 5
                      , grenade
+                     , genvalidity                     >= 0.4.0.4     && < 0.5
+                     , genvalidity-hspec
+                     , genvalidity-hspec-aeson
                      , hedgehog                        >= 0.5         && < 0.6
                      , hmatrix
                      , mtl
@@ -161,6 +168,8 @@ test-suite test
                      , ad
                      , reflection
                      , vector
+                     , QuickCheck
+                     , hspec
 
 
 benchmark bench

--- a/src/Grenade/Core/LearningParameters.hs
+++ b/src/Grenade/Core/LearningParameters.hs
@@ -5,6 +5,10 @@ Copyright   : (c) Huw Campbell, 2016-2017
 License     : BSD2
 Stability   : experimental
 -}
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE RecordWildCards #-}
+
 module Grenade.Core.LearningParameters (
   -- | This module contains learning algorithm specific
   --   code. Currently, this module should be considered
@@ -13,9 +17,27 @@ module Grenade.Core.LearningParameters (
     LearningParameters (..)
   ) where
 
+import GHC.Generics
+
+import Data.Aeson (ToJSON, FromJSON)
+
+import Data.Validity
+
 -- | Learning parameters for stochastic gradient descent.
 data LearningParameters = LearningParameters {
     learningRate :: Double
   , learningMomentum :: Double
   , learningRegulariser :: Double
-  } deriving (Eq, Show)
+  } deriving (Eq, Show, Generic)
+
+instance ToJSON LearningParameters
+
+instance FromJSON LearningParameters
+
+instance Validity LearningParameters where
+    validate LearningParameters {..} =
+        mconcat
+            [ learningRate > 0 <?@> "The learning rate must be strictly positive"
+            , learningMomentum >= 0 <?@> "The momentum parameter must be positive"
+            , learningRegulariser >= 0 <?@> "The regulariser must be positive"
+            ]

--- a/src/Grenade/Utils/Accuracy.hs
+++ b/src/Grenade/Utils/Accuracy.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Grenade.Utils.Accuracy
+    ( Accuracy
+    , HyperParamAccuracy(..)
+    , accuracyM
+    ) where
+
+import Grenade.Core.LearningParameters
+
+import Grenade.Utils.Accuracy.Internal
+
+import GHC.Generics
+
+import Data.Validity
+
+import Data.Aeson (ToJSON, FromJSON)
+
+data HyperParamAccuracy = HyperParamAccuracy
+    { hyperParam :: LearningParameters
+    , testAccuracies :: [Accuracy]
+    , validationAccuracies :: [Accuracy]
+    , trainAccuracies :: [Accuracy]
+    } deriving (Show, Eq, Generic)
+
+instance ToJSON HyperParamAccuracy
+
+instance FromJSON HyperParamAccuracy
+
+instance Validity HyperParamAccuracy

--- a/src/Grenade/Utils/Accuracy/Internal.hs
+++ b/src/Grenade/Utils/Accuracy/Internal.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Grenade.Utils.Accuracy.Internal where
+
+import Data.Validity
+
+import Control.Monad.Catch
+
+import Data.Aeson (ToJSON, FromJSON)
+
+import GHC.Generics
+
+newtype Accuracy = Accuracy Double deriving (Show, Eq, Generic)
+
+data AccuracyNotInRange = AccuracyNotInRange deriving (Show, Eq)
+
+instance Exception AccuracyNotInRange where
+    displayException AccuracyNotInRange = "The accuracy is not in [0,1]."
+
+accuracyM :: MonadThrow m => Double -> m Accuracy
+accuracyM x = case 0 <= x && x <= 1 of
+    False -> throwM AccuracyNotInRange
+    True -> pure $ Accuracy x
+
+instance ToJSON Accuracy
+
+instance FromJSON Accuracy
+
+instance Validity Accuracy where
+    validate (Accuracy x) = 0 <= x && x <= 1 <?@> "The accuracy is in [0,1]"

--- a/test/Test/Grenade/Gen.hs
+++ b/test/Test/Grenade/Gen.hs
@@ -1,0 +1,17 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Test.Grenade.Gen where
+
+import Grenade.Core.LearningParameters
+
+import Data.GenValidity
+
+import Test.QuickCheck.Gen (suchThat)
+
+instance GenUnchecked LearningParameters
+
+instance GenValid LearningParameters where
+    genValid = do
+        rate <- genValid `suchThat` (> 0)
+        momentum <- genValid `suchThat` (>= 0)
+        LearningParameters rate momentum <$> genValid `suchThat` (>= 0)

--- a/test/Test/Grenade/Gen.hs
+++ b/test/Test/Grenade/Gen.hs
@@ -6,6 +6,10 @@ import Grenade.Core.LearningParameters
 
 import Data.GenValidity
 
+import Grenade.Utils.Accuracy
+import Grenade.Utils.Accuracy.Internal
+
+import Test.QuickCheck (choose, listOf)
 import Test.QuickCheck.Gen (suchThat)
 
 instance GenUnchecked LearningParameters
@@ -15,3 +19,17 @@ instance GenValid LearningParameters where
         rate <- genValid `suchThat` (> 0)
         momentum <- genValid `suchThat` (>= 0)
         LearningParameters rate momentum <$> genValid `suchThat` (>= 0)
+
+instance GenUnchecked Accuracy
+
+instance GenValid Accuracy where
+    genValid = Accuracy <$> choose (0,1)
+
+instance GenUnchecked HyperParamAccuracy
+
+instance GenValid HyperParamAccuracy where
+    genValid = do
+        param <- genValid
+        testAcc <- listOf genValid
+        validationAcc <- listOf genValid
+        HyperParamAccuracy param testAcc validationAcc <$> listOf genValid

--- a/test/Test/Grenade/InstanceSpec.hs
+++ b/test/Test/Grenade/InstanceSpec.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Grenade.InstanceSpec where
+
+import Test.Hspec
+
+import Test.Grenade.Gen ()
+
+import Grenade.Core.LearningParameters
+
+import Test.Validity
+import Test.Validity.Aeson
+
+tests :: IO Bool
+tests = hspec spec >> pure True
+
+spec :: Spec
+spec = do
+    genValidSpec @LearningParameters
+    jsonSpecOnValid @LearningParameters

--- a/test/Test/Grenade/InstanceSpec.hs
+++ b/test/Test/Grenade/InstanceSpec.hs
@@ -8,6 +8,7 @@ import Test.Hspec
 import Test.Grenade.Gen ()
 
 import Grenade.Core.LearningParameters
+import Grenade.Utils.Accuracy
 
 import Test.Validity
 import Test.Validity.Aeson
@@ -19,3 +20,7 @@ spec :: Spec
 spec = do
     genValidSpec @LearningParameters
     jsonSpecOnValid @LearningParameters
+    genValidSpec @Accuracy
+    jsonSpecOnValid @Accuracy
+    genValidSpec @HyperParamAccuracy
+    jsonSpecOnValid @HyperParamAccuracy

--- a/test/test.hs
+++ b/test/test.hs
@@ -2,6 +2,8 @@ import           Control.Monad
 
 import qualified Test.Grenade.Network
 
+import qualified Test.Grenade.InstanceSpec
+
 import qualified Test.Grenade.Layers.Pooling
 import qualified Test.Grenade.Layers.Convolution
 import qualified Test.Grenade.Layers.FullyConnected
@@ -18,20 +20,17 @@ import           System.IO
 
 main :: IO ()
 main =
-  disorderMain [
-      Test.Grenade.Network.tests
-
+  disorderMain
+    [ Test.Grenade.Network.tests
+    , Test.Grenade.InstanceSpec.tests
     , Test.Grenade.Layers.Pooling.tests
     , Test.Grenade.Layers.Convolution.tests
     , Test.Grenade.Layers.FullyConnected.tests
     , Test.Grenade.Layers.Nonlinear.tests
     , Test.Grenade.Layers.PadCrop.tests
-
     , Test.Grenade.Layers.Internal.Convolution.tests
     , Test.Grenade.Layers.Internal.Pooling.tests
-
     , Test.Grenade.Recurrent.Layers.LSTM.tests
-
     ]
 
 disorderMain :: [IO Bool] -> IO ()


### PR DESCRIPTION
They keep track of LearningParameters and the corresponding accuracies.
This allows you to calculate train, validation and test accuracy on datasets, and store this info to a file.
This makes it easier to keep track of the sets of hyperparameters which you tried before, how good they were, and how to change them in the next run.

I also tested the json instances using genvalidity-hspec.

I can merge this branch with the branch 'json' if you want to merge the PRs separately.