### PR TITLE
Update ghcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .cabal-sandbox/
 cabal.sandbox.config
 dist/
-
+TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@
 env:
  - CABALVER=1.22 GHCVER=7.10.3
  - CABALVER=1.24 GHCVER=8.0.2
- - CABALVER=2.0 GHCVER=8.2.1
+ - CABALVER=2.0 GHCVER=8.2.2
+ - CABALVER=2.0 GHCVER=8.4.3
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
@@ -27,4 +28,3 @@ notifications:
 script:
  - cabal build
  - cabal test --show-details=streaming
-

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -45,7 +45,7 @@ library
                      , hmatrix                         == 0.18.*
                      , MonadRandom                     >= 0.4         && < 0.6
                      , primitive                       >= 0.6         && < 0.7
-                     , singletons                      >= 2.1         && < 2.4
+                     , singletons                      >= 2.1         && < 2.5
                      , vector                          >= 0.11        && < 0.13
 
   ghc-options:
@@ -176,7 +176,7 @@ benchmark bench
   build-depends:
                        base                            >= 3          && < 5
                      , bytestring                      == 0.10.*
-                     , criterion                       >= 1.1        && < 1.3
+                     , criterion                       >= 1.1        && < 1.6
                      , grenade
                      , hmatrix
 
@@ -193,6 +193,6 @@ benchmark bench-lstm
   build-depends:
                        base                            >= 3          && < 5
                      , bytestring                      == 0.10.*
-                     , criterion                       == 1.1.*
+                     , criterion                       >= 1.1        && < 1.6
                      , grenade
                      , hmatrix

--- a/src/Grenade/Core/Shape.hs
+++ b/src/Grenade/Core/Shape.hs
@@ -35,7 +35,7 @@ import           Data.Singletons.TypeLits
 import           Data.Vector.Storable ( Vector )
 import qualified Data.Vector.Storable as V
 
-import           GHC.TypeLits
+import           GHC.TypeLits hiding (natVal)
 
 import qualified Numeric.LinearAlgebra.Static as H
 import           Numeric.LinearAlgebra.Static

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -29,7 +29,7 @@ import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
 
-import           GHC.TypeLits
+import           GHC.TypeLits hiding (natVal)
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA

--- a/src/Grenade/Layers/Crop.hs
+++ b/src/Grenade/Layers/Crop.hs
@@ -20,7 +20,8 @@ import           Data.Maybe
 import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
-import           GHC.TypeLits
+
+import           GHC.TypeLits hiding (natVal)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad

--- a/src/Grenade/Layers/Deconvolution.hs
+++ b/src/Grenade/Layers/Deconvolution.hs
@@ -33,7 +33,7 @@ import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
 
-import           GHC.TypeLits
+import           GHC.TypeLits hiding (natVal)
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA

--- a/src/Grenade/Layers/Pad.hs
+++ b/src/Grenade/Layers/Pad.hs
@@ -20,7 +20,7 @@ import           Data.Maybe
 import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
-import           GHC.TypeLits
+import           GHC.TypeLits hiding (natVal)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad

--- a/src/Grenade/Layers/Pooling.hs
+++ b/src/Grenade/Layers/Pooling.hs
@@ -21,7 +21,7 @@ import           Data.Maybe
 import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
-import           GHC.TypeLits
+import           GHC.TypeLits hiding (natVal)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pooling

--- a/test/Test/Grenade/Network.hs
+++ b/test/Test/Grenade/Network.hs
@@ -21,7 +21,7 @@ import qualified Data.Vector.Storable as VS
 import qualified Data.Vector.Storable.Mutable as VS ( write )
 import           Data.Singletons
 import           Data.Singletons.Prelude.List
-import           Data.Singletons.TypeLits
+import           Data.Singletons.TypeLits hiding (natVal)
 
 -- import           Data.Type.Equality
 


### PR DESCRIPTION
A few changes in here:
 * add ghc 8.4.3 to travis
 * bump upper bound of singletons
 * fix duplicate imports of `natVal`

On the last point I'm not entirely convinced I've chosen the right source of `natVal`. An example of the compile error is:
```haskell
 test/Test/Grenade/Network.hs:364:40: error:
    Ambiguous occurrence ‘natVal’
    It could refer to either ‘Data.Singletons.TypeLits.natVal’,
                             imported from ‘Data.Singletons.TypeLits’ at test/Test/Grenade/Network.hs:24:1-41
                             (and originally defined in ‘GHC.TypeNats’)
                          or ‘GHC.TypeLits.natVal’,
                             imported from ‘GHC.TypeLits’ at test/Test/Grenade/Network.hs:35:1-29
    |
364 |                         let output_f = natVal f
    |                                        ^^^^^^

```

with the two type signatures being:
 * `GHC.TypeLits.natVal :: forall n proxy. KnownNat n => proxy n -> Integer`
 * `Data.Singletons.TypeLits.natVal :: KnownNat n => proxy n -> Natural`

The change to `Natural` in `singletons` causes some issues in the test cases, which is why the tests use `GHC.TypeLits.natVal` rather than the singletons version.