### PR TITLE
GHC 8.6.3 compatibility

### DIFF
--- a/grenade.cabal
+++ b/grenade.cabal
@@ -7,7 +7,7 @@ maintainer:            Huw Campbell <huw.campbell@gmail.com>
 copyright:             (c) 2016-2017 Huw Campbell.
 synopsis:              Practical Deep Learning in Haskell
 category:              AI, Machine Learning
-cabal-version:         >= 1.8
+cabal-version:         >= 1.10
 build-type:            Simple
 description:
     Grenade is a composable, dependently typed, practical, and fast
@@ -54,6 +54,8 @@ library
                        -Wall
   hs-source-dirs:
                        src
+
+  default-language:    Haskell2010
 
   if impl(ghc < 8.0)
     ghc-options:       -fno-warn-incomplete-patterns
@@ -129,6 +131,7 @@ test-suite test
   hs-source-dirs:
                        test
 
+  default-language:    Haskell2010
 
   other-modules:       Test.Hedgehog.Compat
                        Test.Hedgehog.Hmatrix
@@ -149,6 +152,10 @@ test-suite test
 
   if impl(ghc < 8.0)
     ghc-options:       -fno-warn-incomplete-patterns
+    cpp-options:       -DType=*
+
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
 
   build-depends:
                        base
@@ -178,6 +185,8 @@ benchmark bench
   hs-source-dirs:
                        bench
 
+  default-language:    Haskell2010
+
   build-depends:
                        base
                      , bytestring
@@ -194,6 +203,8 @@ benchmark bench-lstm
 
   hs-source-dirs:
                        bench
+
+  default-language:    Haskell2010
 
   build-depends:
                        base

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -57,6 +57,7 @@ library
 
   if impl(ghc < 8.0)
     ghc-options:       -fno-warn-incomplete-patterns
+    cpp-options:       -DType=*
 
   if impl(ghc >= 8.6)
     default-extensions: NoStarIsType

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
                        base                            >= 4.8         && < 5
                      , bytestring                      == 0.10.*
-                     , containers                      >= 0.5         && < 0.6
+                     , containers                      >= 0.5         && < 0.7
                      , cereal                          >= 0.5         && < 0.6
                      , deepseq                         >= 1.4         && < 1.5
                      , hmatrix                         == 0.18.*

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -42,7 +42,7 @@ library
                      , containers                      >= 0.5         && < 0.7
                      , cereal                          >= 0.5         && < 0.6
                      , deepseq                         >= 1.4         && < 1.5
-                     , hmatrix                         == 0.18.*
+                     , hmatrix                         >= 0.18        && < 0.20
                      , MonadRandom                     >= 0.4         && < 0.6
                      , primitive                       >= 0.6         && < 0.7
                      -- Versions of singletons are *tightly* coupled with the

--- a/grenade.cabal
+++ b/grenade.cabal
@@ -58,6 +58,8 @@ library
   if impl(ghc < 8.0)
     ghc-options:       -fno-warn-incomplete-patterns
 
+  if impl(ghc >= 8.6)
+    default-extensions: NoStarIsType
 
   exposed-modules:
                        Grenade

--- a/src/Grenade/Core/Layer.hs
+++ b/src/Grenade/Core/Layer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -41,7 +42,9 @@ import           Control.Monad.Random ( MonadRandom )
 
 import           Data.List ( foldl' )
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core.Shape
 import           Grenade.Core.LearningParameters

--- a/src/Grenade/Core/Layer.hs
+++ b/src/Grenade/Core/Layer.hs
@@ -41,6 +41,8 @@ import           Control.Monad.Random ( MonadRandom )
 
 import           Data.List ( foldl' )
 
+import           Data.Kind (Type)
+
 import           Grenade.Core.Shape
 import           Grenade.Core.LearningParameters
 
@@ -50,7 +52,7 @@ import           Grenade.Core.LearningParameters
 class UpdateLayer x where
   -- | The type for the gradient for this layer.
   --   Unit if there isn't a gradient to pass back.
-  type Gradient x :: *
+  type Gradient x :: Type
 
   -- | Update a layer with its gradient and learning parameters
   runUpdate       :: LearningParameters -> x -> Gradient x -> x
@@ -72,7 +74,7 @@ class UpdateLayer x => Layer x (i :: Shape) (o :: Shape) where
   -- | The Wengert tape for this layer. Includes all that is required
   --   to generate the back propagated gradients efficiently. As a
   --   default, `S i` is fine.
-  type Tape x i o :: *
+  type Tape x i o :: Type
 
   -- | Used in training and scoring. Take the input from the previous
   --   layer, and give the output from this layer.

--- a/src/Grenade/Core/Network.hs
+++ b/src/Grenade/Core/Network.hs
@@ -36,6 +36,8 @@ import           Data.Singletons
 import           Data.Singletons.Prelude
 import           Data.Serialize
 
+import           Data.Kind (Type)
+
 import           Grenade.Core.Layer
 import           Grenade.Core.LearningParameters
 import           Grenade.Core.Shape
@@ -48,7 +50,7 @@ import           Grenade.Core.Shape
 --
 --   Can be considered to be a heterogeneous list of layers which are able to
 --   transform the data shapes of the network.
-data Network :: [*] -> [Shape] -> * where
+data Network :: [Type] -> [Shape] -> Type where
     NNil  :: SingI i
           => Network '[] '[i]
 
@@ -66,7 +68,7 @@ instance (Show x, Show (Network xs rs)) => Show (Network (x ': xs) (i ': rs)) wh
 -- | Gradient of a network.
 --
 --   Parameterised on the layers of the network.
-data Gradients :: [*] -> * where
+data Gradients :: [Type] -> Type where
    GNil  :: Gradients '[]
 
    (:/>) :: UpdateLayer x
@@ -77,7 +79,7 @@ data Gradients :: [*] -> * where
 -- | Wegnert Tape of a network.
 --
 --   Parameterised on the layers and shapes of the network.
-data Tapes :: [*] -> [Shape] -> * where
+data Tapes :: [Type] -> [Shape] -> Type where
    TNil  :: SingI i
          => Tapes '[] '[i]
 
@@ -152,7 +154,7 @@ applyUpdate _ NNil GNil
 
 -- | A network can easily be created by hand with (:~>), but an easy way to
 --   initialise a random network is with the randomNetwork.
-class CreatableNetwork (xs :: [*]) (ss :: [Shape]) where
+class CreatableNetwork (xs :: [Type]) (ss :: [Shape]) where
   -- | Create a network with randomly initialised weights.
   --
   --   Calls to this function will not compile if the type of the neural

--- a/src/Grenade/Core/Network.hs
+++ b/src/Grenade/Core/Network.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE GADTs                 #-}
@@ -36,7 +37,9 @@ import           Data.Singletons
 import           Data.Singletons.Prelude
 import           Data.Serialize
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core.Layer
 import           Grenade.Core.LearningParameters

--- a/src/Grenade/Core/Shape.hs
+++ b/src/Grenade/Core/Shape.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Shape
 Description : Dependently typed shapes of data which are passed between layers of a network

--- a/src/Grenade/Core/Shape.hs
+++ b/src/Grenade/Core/Shape.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Shape

--- a/src/Grenade/Layers/Concat.hs
+++ b/src/Grenade/Layers/Concat.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Concat

--- a/src/Grenade/Layers/Concat.hs
+++ b/src/Grenade/Layers/Concat.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -26,7 +27,10 @@ import           Data.Serialize
 
 import           Data.Singletons
 import           GHC.TypeLits
+
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 

--- a/src/Grenade/Layers/Concat.hs
+++ b/src/Grenade/Layers/Concat.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Concat
 Description : Concatenation layer
@@ -25,6 +27,7 @@ import           Data.Serialize
 
 import           Data.Singletons
 import           GHC.TypeLits
+import           Data.Kind (Type)
 
 import           Grenade.Core
 
@@ -43,7 +46,7 @@ import           Numeric.LinearAlgebra.Static ( row, (===), splitRows, unrow, (#
 --
 -- 3D images become 3D images with more channels. The sizes must be the same, one can use Pad
 -- and Crop layers to ensure this is the case.
-data Concat :: Shape -> * -> Shape -> * -> * where
+data Concat :: Shape -> Type -> Shape -> Type -> Type where
   Concat :: x -> y -> Concat m x n y
 
 instance (Show x, Show y) => Show (Concat m x n y) where

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Convolution

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -36,7 +36,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Convolution
 Description : Convolution layer
@@ -35,6 +37,7 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+import           Data.Kind (Type)
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA
@@ -61,7 +64,7 @@ data Convolution :: Nat -- Number of channels, for the first layer this could be
                  -> Nat -- The number of column in the kernel filter
                  -> Nat -- The row stride of the convolution filter
                  -> Nat -- The columns stride of the convolution filter
-                 -> * where
+                 -> Type where
   Convolution :: ( KnownNat channels
                  , KnownNat filters
                  , KnownNat kernelRows
@@ -80,7 +83,7 @@ data Convolution' :: Nat -- Number of channels, for the first layer this could b
                   -> Nat -- The number of column in the kernel filter
                   -> Nat -- The row stride of the convolution filter
                   -> Nat -- The columns stride of the convolution filter
-                  -> * where
+                  -> Type where
   Convolution' :: ( KnownNat channels
                   , KnownNat filters
                   , KnownNat kernelRows

--- a/src/Grenade/Layers/Crop.hs
+++ b/src/Grenade/Layers/Crop.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Crop

--- a/src/Grenade/Layers/Crop.hs
+++ b/src/Grenade/Layers/Crop.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Crop
 Description : Cropping layer
@@ -27,6 +29,7 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+import           Data.Kind (Type)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad
@@ -38,7 +41,7 @@ import           Numeric.LinearAlgebra.Static (extract, create)
 data Crop :: Nat
           -> Nat
           -> Nat
-          -> Nat -> * where
+          -> Nat -> Type where
   Crop :: Crop cropLeft cropTop cropRight cropBottom
 
 instance Show (Crop cropLeft cropTop cropRight cropBottom) where

--- a/src/Grenade/Layers/Crop.hs
+++ b/src/Grenade/Layers/Crop.hs
@@ -28,7 +28,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad

--- a/src/Grenade/Layers/Deconvolution.hs
+++ b/src/Grenade/Layers/Deconvolution.hs
@@ -40,7 +40,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA

--- a/src/Grenade/Layers/Deconvolution.hs
+++ b/src/Grenade/Layers/Deconvolution.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Deconvolution

--- a/src/Grenade/Layers/Deconvolution.hs
+++ b/src/Grenade/Layers/Deconvolution.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Deconvolution
 Description : Deconvolution layer
@@ -39,6 +41,7 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+import           Data.Kind (Type)
 
 import           Numeric.LinearAlgebra hiding ( uniformSample, konst )
 import qualified Numeric.LinearAlgebra as LA
@@ -60,7 +63,7 @@ data Deconvolution :: Nat -- Number of channels, for the first layer this could 
                    -> Nat -- The number of column in the kernel filter
                    -> Nat -- The row stride of the Deconvolution filter
                    -> Nat -- The columns stride of the Deconvolution filter
-                   -> * where
+                   -> Type where
   Deconvolution :: ( KnownNat channels
                    , KnownNat filters
                    , KnownNat kernelRows
@@ -79,7 +82,7 @@ data Deconvolution' :: Nat -- Number of channels, for the first layer this could
                     -> Nat -- The number of column in the kernel filter
                     -> Nat -- The row stride of the Deconvolution filter
                     -> Nat -- The columns stride of the Deconvolution filter
-                    -> * where
+                    -> Type where
   Deconvolution' :: ( KnownNat channels
                   , KnownNat filters
                   , KnownNat kernelRows

--- a/src/Grenade/Layers/Merge.hs
+++ b/src/Grenade/Layers/Merge.hs
@@ -23,13 +23,15 @@ import           Data.Serialize
 
 import           Data.Singletons
 
+import           Data.Kind (Type)
+
 import           Grenade.Core
 
 -- | A Merging layer.
 --
 -- Similar to Concat layer, except sums the activations instead of creating a larger
 -- shape.
-data Merge :: * -> * -> * where
+data Merge :: Type -> Type -> Type where
   Merge :: x -> y -> Merge x y
 
 instance (Show x, Show y) => Show (Merge x y) where

--- a/src/Grenade/Layers/Merge.hs
+++ b/src/Grenade/Layers/Merge.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -23,7 +24,9 @@ import           Data.Serialize
 
 import           Data.Singletons
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 

--- a/src/Grenade/Layers/Pad.hs
+++ b/src/Grenade/Layers/Pad.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Pad
 Description : Padding layer for 2D and 3D images
@@ -27,6 +29,7 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+import           Data.Kind (Type)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad
@@ -40,7 +43,7 @@ import           Numeric.LinearAlgebra.Static (extract, create)
 data Pad  :: Nat
           -> Nat
           -> Nat
-          -> Nat -> * where
+          -> Nat -> Type where
   Pad  :: Pad padLeft padTop padRight padBottom
 
 instance Show (Pad padLeft padTop padRight padBottom) where

--- a/src/Grenade/Layers/Pad.hs
+++ b/src/Grenade/Layers/Pad.hs
@@ -28,7 +28,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pad

--- a/src/Grenade/Layers/Pad.hs
+++ b/src/Grenade/Layers/Pad.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Pad

--- a/src/Grenade/Layers/Pooling.hs
+++ b/src/Grenade/Layers/Pooling.hs
@@ -7,6 +7,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Pooling
 Description : Max Pooling layer for 2D and 3D images
@@ -28,6 +30,7 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+import           Data.Kind (Type)
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pooling
@@ -42,7 +45,7 @@ import           Numeric.LinearAlgebra.Static as LAS hiding ((|||), build, toRow
 --   The kernel size dictates which input and output sizes will "fit". Fitting the equation:
 --   `out = (in - kernel) / stride + 1` for both dimensions.
 --
-data Pooling :: Nat -> Nat -> Nat -> Nat -> * where
+data Pooling :: Nat -> Nat -> Nat -> Nat -> Type where
   Pooling :: Pooling kernelRows kernelColumns strideRows strideColumns
 
 instance Show (Pooling k k' s s') where

--- a/src/Grenade/Layers/Pooling.hs
+++ b/src/Grenade/Layers/Pooling.hs
@@ -29,7 +29,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 import           Grenade.Layers.Internal.Pooling

--- a/src/Grenade/Layers/Pooling.hs
+++ b/src/Grenade/Layers/Pooling.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Core.Pooling

--- a/src/Grenade/Layers/Reshape.hs
+++ b/src/Grenade/Layers/Reshape.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE NoStarIsType          #-}
 {-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Reshape

--- a/src/Grenade/Layers/Reshape.hs
+++ b/src/Grenade/Layers/Reshape.hs
@@ -3,6 +3,8 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE NoStarIsType          #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Reshape
 Description : Multipurpose reshaping layer

--- a/src/Grenade/Recurrent/Core/Layer.hs
+++ b/src/Grenade/Recurrent/Core/Layer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -8,7 +9,9 @@ module Grenade.Recurrent.Core.Layer (
   , RecurrentUpdateLayer (..)
   ) where
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 

--- a/src/Grenade/Recurrent/Core/Layer.hs
+++ b/src/Grenade/Recurrent/Core/Layer.hs
@@ -8,6 +8,8 @@ module Grenade.Recurrent.Core.Layer (
   , RecurrentUpdateLayer (..)
   ) where
 
+import           Data.Kind (Type)
+
 import           Grenade.Core
 
 -- | Class for a recurrent layer.
@@ -15,11 +17,11 @@ import           Grenade.Core
 --   of an extra recurrent data shape.
 class UpdateLayer x => RecurrentUpdateLayer x where
   -- | Shape of data that is passed between each subsequent run of the layer
-  type RecurrentShape x   :: *
+  type RecurrentShape x   :: Type
 
 class (RecurrentUpdateLayer x, Num (RecurrentShape x)) => RecurrentLayer x (i :: Shape) (o :: Shape) where
   -- | Wengert Tape
-  type RecTape x i o :: *
+  type RecTape x i o :: Type
   -- | Used in training and scoring. Take the input from the previous
   --   layer, and give the output from this layer.
   runRecurrentForwards    :: x -> RecurrentShape x -> S i -> (RecTape x i o, RecurrentShape x, S o)

--- a/src/Grenade/Recurrent/Core/Network.hs
+++ b/src/Grenade/Recurrent/Core/Network.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -32,7 +33,9 @@ import           Data.Singletons ( SingI )
 import           Data.Singletons.Prelude ( Head, Last )
 import           Data.Serialize
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 import           Grenade.Recurrent.Core.Layer

--- a/src/Grenade/Recurrent/Core/Network.hs
+++ b/src/Grenade/Recurrent/Core/Network.hs
@@ -32,18 +32,20 @@ import           Data.Singletons ( SingI )
 import           Data.Singletons.Prelude ( Head, Last )
 import           Data.Serialize
 
+import           Data.Kind (Type)
+
 import           Grenade.Core
 import           Grenade.Recurrent.Core.Layer
 
 -- | Witness type to say indicate we're building up with a normal feed
 --   forward layer.
-data FeedForward :: * -> *
+data FeedForward :: Type -> Type
 -- | Witness type to say indicate we're building up with a recurrent layer.
-data Recurrent :: * -> *
+data Recurrent :: Type -> Type
 
 -- | Type of a recurrent neural network.
 --
---   The [*] type specifies the types of the layers.
+--   The [Type] type specifies the types of the layers.
 --
 --   The [Shape] type specifies the shapes of data passed between the layers.
 --
@@ -52,7 +54,7 @@ data Recurrent :: * -> *
 --
 --   Often, to make the definitions more concise, one will use a type alias
 --   for these empty data types.
-data RecurrentNetwork :: [*] -> [Shape] -> * where
+data RecurrentNetwork :: [Type] -> [Shape] -> Type where
   RNil   :: SingI i
          => RecurrentNetwork '[] '[i]
 
@@ -71,7 +73,7 @@ infixr 5 :~@>
 -- | Gradient of a network.
 --
 --   Parameterised on the layers of the network.
-data RecurrentGradient :: [*] -> * where
+data RecurrentGradient :: [Type] -> Type where
    RGNil  :: RecurrentGradient '[]
 
    (://>) :: UpdateLayer x
@@ -81,7 +83,7 @@ data RecurrentGradient :: [*] -> * where
 
 -- | Recurrent inputs (sideways shapes on an imaginary unrolled graph)
 --   Parameterised on the layers of a Network.
-data RecurrentInputs :: [*] -> * where
+data RecurrentInputs :: [Type] -> Type where
    RINil   :: RecurrentInputs '[]
 
    (:~~+>) :: (UpdateLayer x, Fractional (RecurrentInputs xs))
@@ -95,7 +97,7 @@ data RecurrentInputs :: [*] -> * where
 --
 --   We index on the time step length as well, to ensure
 --   that that all Tape lengths are the same.
-data RecurrentTape :: [*] -> [Shape] -> * where
+data RecurrentTape :: [Type] -> [Shape] -> Type where
    TRNil  :: SingI i
           => RecurrentTape '[] '[i]
 
@@ -204,7 +206,7 @@ instance (Show x, Show (RecurrentNetwork xs rs)) => Show (RecurrentNetwork (Recu
 
 -- | A network can easily be created by hand with (:~~>) and (:~@>), but an easy way to initialise a random
 --   recurrent network and a set of random inputs for it is with the randomRecurrent.
-class CreatableRecurrent (xs :: [*]) (ss :: [Shape]) where
+class CreatableRecurrent (xs :: [Type]) (ss :: [Shape]) where
   -- | Create a network of the types requested
   randomRecurrent :: MonadRandom m => m (RecurrentNetwork xs ss)
 

--- a/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE RecordWildCards       #-}
@@ -18,7 +19,9 @@ import           Control.Monad.Random ( MonadRandom, getRandom )
 
 import           Data.Singletons.TypeLits
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Numeric.LinearAlgebra.Static
 

--- a/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
@@ -18,6 +18,8 @@ import           Control.Monad.Random ( MonadRandom, getRandom )
 
 import           Data.Singletons.TypeLits
 
+import           Data.Kind (Type)
+
 import           Numeric.LinearAlgebra.Static
 
 import           GHC.TypeLits
@@ -27,7 +29,7 @@ import           Grenade.Recurrent.Core
 
 data BasicRecurrent :: Nat -- Input layer size
                     -> Nat -- Output layer size
-                    -> * where
+                    -> Type where
   BasicRecurrent :: ( KnownNat input
                     , KnownNat output
                     , KnownNat matrixCols
@@ -40,7 +42,7 @@ data BasicRecurrent :: Nat -- Input layer size
 
 data BasicRecurrent' :: Nat -- Input layer size
                      -> Nat -- Output layer size
-                     -> * where
+                     -> Type where
   BasicRecurrent' :: ( KnownNat input
                      , KnownNat output
                      , KnownNat matrixCols

--- a/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -27,7 +28,9 @@ import           Data.Serialize
 import           Data.Singletons
 import           GHC.TypeLits
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import           Grenade.Core
 import           Grenade.Recurrent.Core

--- a/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
@@ -27,6 +27,8 @@ import           Data.Serialize
 import           Data.Singletons
 import           GHC.TypeLits
 
+import           Data.Kind (Type)
+
 import           Grenade.Core
 import           Grenade.Recurrent.Core
 
@@ -45,7 +47,7 @@ import           Numeric.LinearAlgebra.Static ( (#), split, R )
 --
 -- 3D images become 3D images with more channels. The sizes must be the same, one can use Pad
 -- and Crop layers to ensure this is the case.
-data ConcatRecurrent :: Shape -> * -> Shape -> * -> * where
+data ConcatRecurrent :: Shape -> Type -> Shape -> Type -> Type where
   ConcatRecLeft  :: x -> y -> ConcatRecurrent m (Recurrent x) n (FeedForward y)
   ConcatRecRight :: x -> y -> ConcatRecurrent m (FeedForward x) n (Recurrent y)
   ConcatRecBoth  :: x -> y -> ConcatRecurrent m (Recurrent x) n   (Recurrent y)

--- a/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/ConcatRecurrent.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StandaloneDeriving    #-}
+{-# LANGUAGE UndecidableInstances  #-}
 {-|
 Module      : Grenade.Layers.Concat
 Description : Concatenation layer

--- a/src/Grenade/Recurrent/Layers/LSTM.hs
+++ b/src/Grenade/Recurrent/Layers/LSTM.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
@@ -23,7 +24,9 @@ import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
 
+#if MIN_VERSION_base(4,9,0)
 import           Data.Kind (Type)
+#endif
 
 import qualified Numeric.LinearAlgebra as LA
 import           Numeric.LinearAlgebra.Static

--- a/src/Grenade/Recurrent/Layers/LSTM.hs
+++ b/src/Grenade/Recurrent/Layers/LSTM.hs
@@ -23,6 +23,8 @@ import           Data.Proxy
 import           Data.Serialize
 import           Data.Singletons.TypeLits
 
+import           Data.Kind (Type)
+
 import qualified Numeric.LinearAlgebra as LA
 import           Numeric.LinearAlgebra.Static
 
@@ -36,14 +38,14 @@ import           Grenade.Layers.Internal.Update
 --   This is a Peephole formulation, so the recurrent shape is
 --   just the cell state, the previous output is not held or used
 --   at all.
-data LSTM :: Nat -> Nat -> * where
+data LSTM :: Nat -> Nat -> Type where
   LSTM :: ( KnownNat input
           , KnownNat output
           ) => !(LSTMWeights input output) -- Weights
             -> !(LSTMWeights input output) -- Momentums
             -> LSTM input output
 
-data LSTMWeights :: Nat -> Nat -> * where
+data LSTMWeights :: Nat -> Nat -> Type where
   LSTMWeights :: ( KnownNat input
                  , KnownNat output
                  ) => {

--- a/test/Test/Grenade/Layers/Convolution.hs
+++ b/test/Test/Grenade/Layers/Convolution.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
@@ -15,6 +16,10 @@ import           Data.Singletons ()
 import           GHC.TypeLits
 import           GHC.TypeLits.Witnesses
 
+#if MIN_VERSION_base(4,9,0)
+import           Data.Kind (Type)
+#endif
+
 import           Grenade.Core
 import           Grenade.Layers.Convolution
 
@@ -25,7 +30,7 @@ import           Test.Hedgehog.Hmatrix
 import           Test.Hedgehog.TypeLits
 import           Test.Hedgehog.Compat
 
-data OpaqueConvolution :: * where
+data OpaqueConvolution :: Type where
      OpaqueConvolution :: Convolution channels filters kernelRows kernelColumns strideRows strideColumns -> OpaqueConvolution
 
 instance Show OpaqueConvolution where

--- a/test/Test/Grenade/Layers/FullyConnected.hs
+++ b/test/Test/Grenade/Layers/FullyConnected.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE DataKinds           #-}
@@ -12,6 +13,10 @@ import           Data.Singletons ()
 
 import           GHC.TypeLits
 
+#if MIN_VERSION_base(4,9,0)
+import           Data.Kind (Type)
+#endif
+
 import           Grenade.Core
 import           Grenade.Layers.FullyConnected
 
@@ -20,7 +25,7 @@ import           Hedgehog
 import           Test.Hedgehog.Compat
 import           Test.Hedgehog.Hmatrix
 
-data OpaqueFullyConnected :: * where
+data OpaqueFullyConnected :: Type where
      OpaqueFullyConnected :: (KnownNat i, KnownNat o) => FullyConnected i o -> OpaqueFullyConnected
 
 instance Show OpaqueFullyConnected where

--- a/test/Test/Grenade/Layers/Pooling.hs
+++ b/test/Test/Grenade/Layers/Pooling.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE TemplateHaskell     #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE KindSignatures      #-}
@@ -9,6 +10,10 @@ module Test.Grenade.Layers.Pooling where
 import           Data.Proxy
 import           Data.Singletons ()
 
+#if MIN_VERSION_base(4,9,0)
+import           Data.Kind (Type)
+#endif
+
 import           GHC.TypeLits
 import           Grenade.Layers.Pooling
 
@@ -16,7 +21,7 @@ import           Hedgehog
 
 import           Test.Hedgehog.Compat
 
-data OpaquePooling :: * where
+data OpaquePooling :: Type where
      OpaquePooling :: (KnownNat kh, KnownNat kw, KnownNat sh, KnownNat sw) => Pooling kh kw sh sw -> OpaquePooling
 
 instance Show OpaquePooling where
@@ -24,10 +29,10 @@ instance Show OpaquePooling where
 
 genOpaquePooling :: Gen OpaquePooling
 genOpaquePooling = do
-    Just kernelHeight <- someNatVal <$> choose 2 15
-    Just kernelWidth  <- someNatVal <$> choose 2 15
-    Just strideHeight <- someNatVal <$> choose 2 15
-    Just strideWidth  <- someNatVal <$> choose 2 15
+    ~(Just kernelHeight) <- someNatVal <$> choose 2 15
+    ~(Just kernelWidth ) <- someNatVal <$> choose 2 15
+    ~(Just strideHeight) <- someNatVal <$> choose 2 15
+    ~(Just strideWidth ) <- someNatVal <$> choose 2 15
 
     case (kernelHeight, kernelWidth, strideHeight, strideWidth) of
        (SomeNat (_ :: Proxy kh), SomeNat (_ :: Proxy kw), SomeNat (_ :: Proxy sh), SomeNat (_ :: Proxy sw)) ->

--- a/test/Test/Grenade/Network.hs
+++ b/test/Test/Grenade/Network.hs
@@ -35,6 +35,9 @@ import           GHC.TypeLits hiding (natVal)
 #else
 import           GHC.TypeLits
 #endif
+#if MIN_VERSION_base(4,9,0)
+import           Data.Kind (Type)
+#endif
 
 import           GHC.TypeLits.Witnesses
 import           Test.Hedgehog.Compat
@@ -46,7 +49,7 @@ import           Numeric.LinearAlgebra ( flatten )
 import           Numeric.LinearAlgebra.Static ( extract, norm_Inf )
 import           Unsafe.Coerce
 
-data SomeNetwork :: * where
+data SomeNetwork :: Type where
     SomeNetwork :: ( SingI shapes, SingI (Head shapes), SingI (Last shapes), Show (Network layers shapes) ) => Network layers shapes -> SomeNetwork
 
 instance Show SomeNetwork where
@@ -448,7 +451,7 @@ oneUp =
     D1Sing SNat ->
       let x = 0 :: S ( shape )
       in  case x of
-              ( S1D x' ) -> do
+            ( S1D x' ) -> do
               let ex = extract x'
               let len = VS.length ex
               ix <- choose 0 (len - 1)
@@ -460,7 +463,7 @@ oneUp =
     D2Sing SNat SNat ->
       let x = 0 :: S ( shape )
       in  case x of
-              ( S2D x' ) -> do
+            ( S2D x' ) -> do
               let ex = flatten ( extract x' )
               let len = VS.length ex
               ix <- choose 0 (len - 1)
@@ -472,7 +475,7 @@ oneUp =
     D3Sing SNat SNat SNat ->
       let x = 0 :: S ( shape )
       in  case x of
-              ( S3D x' ) -> do
+            ( S3D x' ) -> do
               let ex = flatten ( extract x' )
               let len = VS.length ex
               ix <- choose 0 (len - 1)

--- a/test/Test/Hedgehog/TypeLits.hs
+++ b/test/Test/Hedgehog/TypeLits.hs
@@ -24,7 +24,7 @@ import           Test.Hedgehog.Compat
 
 genNat :: Gen SomeNat
 genNat = do
-  Just n <- someNatVal <$> choose 1 10
+  ~(Just n) <- someNatVal <$> choose 1 10
   return n
 
 #if __GLASGOW_HASKELL__ < 800


### PR DESCRIPTION
Fixes #78.

I tested that it compiles successfully with GHCs 7.10.3, 8.0.2, 8.2.2, 8.4.4, 8.6.3, but I haven't checked that it works correctly in all those versions.  Seems to work in GHC-8.6.3 at least (I get some ASCII circles with the feedforward example, and ASCII glyphs with the gan-mnist example).