### PR TITLE
travis: Drop ghc 7.10.3 and use ghc 8.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,9 @@
 
 # The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
 env:
- - CABALVER=1.22 GHCVER=7.10.3
  - CABALVER=1.24 GHCVER=8.0.2
  - CABALVER=2.0 GHCVER=8.2.2
- - CABALVER=2.0 GHCVER=8.4.3
+ - CABALVER=2.0 GHCVER=8.4.4
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:


### PR DESCRIPTION
Since this project uses some of the new dependent types features of GHC
keeping it working with multiple GHC versions is going to be difficult.
Drop 7.10.3 because it has already stoppped working.