### PR TITLE
Docker image with Grenade built inside

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,11 @@ RUN stack build
 RUN echo ':set prompt "\ESC[34mλ> \ESC[m"' > ~/.ghci
 
 #
+# Choose default main object to run GHCI
+#
+ENV GRENADE_MAIN=mnist
+
+#
 # Run GHC repl
 #
-CMD [ "stack", "ghci" ]
+CMD stack ghci --main-is grenade-examples:exe:$GRENADE_MAIN

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# 
+# NOTE: Tried with Haskell 8.2 and 8.0 and ended up with some build errors
+#
+FROM haskell:8.4
+
+RUN mkdir /grenade
+COPY . /grenade
+
+# 
+# Install system dependencies
+# 
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    gfortran \
+    libatlas-base-dev \
+    libgsl0-dev \
+    liblapack-dev \
+    python \
+    wget
+
+#
+# Install Open Blas (with Lapack included)
+# This is a depencency for building hmatrix package
+#
+ENV OPEN_BLAS_VER=0.2.20
+RUN wget http://github.com/xianyi/OpenBLAS/archive/v$OPEN_BLAS_VER.tar.gz
+RUN tar -xzvf v$OPEN_BLAS_VER.tar.gz
+
+WORKDIR /OpenBLAS-$OPEN_BLAS_VER
+RUN ls -la
+RUN make FC=gfortran
+RUN make PREFIX=/usr/local install
+
+#
+# Build and setup grenade
+#
+WORKDIR /grenade
+
+RUN stack init
+RUN stack setup --install-ghc
+RUN stack build
+
+# Optional GHCI prompt configuration
+RUN echo ':set prompt "\ESC[34mλ> \ESC[m"' > ~/.ghci
+
+#
+# Run GHC repl
+#
+CMD [ "stack", "ghci" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,2 @@
+grenade:
+  build: .


### PR DESCRIPTION
It took me a while to success on building Grenade on my machine, so I ended up creating a Docker image with all the steps for building Grenade from scratch.

I uploaded the image to Docker Hub:
[
https://cloud.docker.com/repository/docker/leopiney/grenade](https://cloud.docker.com/repository/docker/leopiney/grenade)

I don't mean this PR to be merged to master, but it might be useful for someone who wants to try grenade and skip the building process 😛 

Just type `docker run --interactive leopiney/grenade` and you'll be running grenade with `stack ghci`

Related #77 #36 #27 