### PR TITLE
Remove use of RecordWildCards

### DIFF
--- a/examples/main/shakespeare.hs
+++ b/examples/main/shakespeare.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns          #-}
 {-# LANGUAGE CPP                   #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TypeOperators         #-}
@@ -83,34 +82,34 @@ loadShakespeare path = do
   return (V.fromList hot, m, cs)
 
 trainSlice :: LearningParameters -> Shakespeare -> Shakespearian -> Vector Int -> Int -> Int -> (Shakespeare, Shakespearian)
-trainSlice !rate !net !recIns input offset size =
+trainSlice !lrate !net !recIns input offset size =
   let e = fmap (x . oneHot) . V.toList $ V.slice offset size input
   in case reverse e of
     (o : l : xs) ->
       let examples = reverse $ (l, Just o) : ((,Nothing) <$> xs)
-      in  trainRecurrent rate net recIns examples
+      in  trainRecurrent lrate net recIns examples
     _ -> error "Not enough input"
     where
       x = fromMaybe (error "Hot variable didn't fit.")
 
 runShakespeare :: ShakespeareOpts -> ExceptT String IO ()
-runShakespeare ShakespeareOpts {..} = do
-  (shakespeare, oneHotMap, oneHotDictionary) <- loadShakespeare trainingFile
+runShakespeare opts = do
+  (shakespeare, oneHotMap, oneHotDictionary) <- loadShakespeare $ trainingFile opts
   (net0, i0) <- lift $
-    case loadPath of
+    case loadPath opts of
       Just loadFile -> netLoad loadFile
       Nothing -> (,0) <$> randomNet
 
   (trained, bestInput) <- lift $ foldM (\(!net, !io) size -> do
-    xs <- take (iterations `div` 10) <$> getRandomRs (0, length shakespeare - size - 1)
-    let (!trained, !bestInput) = foldl' (\(!n, !i) offset -> trainSlice rate n i shakespeare offset size) (net, io) xs
-    results <- take 1000 <$> generateParagraph trained bestInput temperature oneHotMap oneHotDictionary ( S1D $ konst 0)
+    xs <- take (iterations opts `div` 10) <$> getRandomRs (0, length shakespeare - size - 1)
+    let (!trained, !bestInput) = foldl' (\(!n, !i) offset -> trainSlice (rate opts) n i shakespeare offset size) (net, io) xs
+    results <- take 1000 <$> generateParagraph trained bestInput (temperature opts) oneHotMap oneHotDictionary ( S1D $ konst 0)
     putStrLn ("TRAINING STEP WITH SIZE: " ++ show size)
     putStrLn (unAnnotateCapitals results)
     return (trained, bestInput)
-    ) (net0, i0) $ replicate 10 sequenceSize
+    ) (net0, i0) $ replicate 10 (sequenceSize opts)
 
-  case savePath of
+  case savePath opts of
     Just saveFile -> lift . B.writeFile saveFile $ runPut (put trained >> put bestInput)
     Nothing -> return ()
 
@@ -122,12 +121,12 @@ generateParagraph :: forall layers shapes n a. (Last shapes ~ 'D1 n, Head shapes
   -> Vector a
   -> S ('D1 n)
   -> IO [a]
-generateParagraph n s temperature hotmap hotdict =
+generateParagraph n s temp hotmap hotdict =
   go s
     where
   go x y =
     do let (_, ns, o) = runRecurrent n x y
-       un            <- sample temperature hotdict o
+       un            <- sample temp hotdict o
        Just re       <- return $ makeHot hotmap un
        rest          <- unsafeInterleaveIO $ go ns re
        return (un : rest)

--- a/src/Grenade/Layers/Convolution.hs
+++ b/src/Grenade/Layers/Convolution.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -139,8 +138,8 @@ instance ( KnownNat channels
          , KnownNat (kernelRows * kernelColumns * channels)
          ) => UpdateLayer (Convolution channels filters kernelRows kernelColumns strideRows strideColumns) where
   type Gradient (Convolution channels filters kernelRows kernelColumns strideRows strideColumns) = (Convolution' channels filters kernelRows kernelColumns strideRows strideColumns)
-  runUpdate LearningParameters {..} (Convolution oldKernel oldMomentum) (Convolution' kernelGradient) =
-    let (newKernel, newMomentum) = descendMatrix learningRate learningMomentum learningRegulariser oldKernel kernelGradient oldMomentum
+  runUpdate lp (Convolution oldKernel oldMomentum) (Convolution' kernelGradient) =
+    let (newKernel, newMomentum) = descendMatrix (learningRate lp) (learningMomentum lp) (learningRegulariser lp) oldKernel kernelGradient oldMomentum
     in Convolution newKernel newMomentum
 
   createRandom = randomConvolution

--- a/src/Grenade/Layers/Deconvolution.hs
+++ b/src/Grenade/Layers/Deconvolution.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
@@ -138,8 +137,8 @@ instance ( KnownNat channels
          , KnownNat (kernelRows * kernelColumns * filters)
          ) => UpdateLayer (Deconvolution channels filters kernelRows kernelColumns strideRows strideColumns) where
   type Gradient (Deconvolution channels filters kernelRows kernelColumns strideRows strideColumns) = (Deconvolution' channels filters kernelRows kernelColumns strideRows strideColumns)
-  runUpdate LearningParameters {..} (Deconvolution oldKernel oldMomentum) (Deconvolution' kernelGradient) =
-    let (newKernel, newMomentum) = descendMatrix learningRate learningMomentum learningRegulariser oldKernel kernelGradient oldMomentum
+  runUpdate lp (Deconvolution oldKernel oldMomentum) (Deconvolution' kernelGradient) =
+    let (newKernel, newMomentum) = descendMatrix (learningRate lp) (learningMomentum lp) (learningRegulariser lp) oldKernel kernelGradient oldMomentum
     in Deconvolution newKernel newMomentum
 
   createRandom = randomDeconvolution

--- a/src/Grenade/Layers/FullyConnected.hs
+++ b/src/Grenade/Layers/FullyConnected.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -38,9 +37,9 @@ instance Show (FullyConnected i o) where
 instance (KnownNat i, KnownNat o) => UpdateLayer (FullyConnected i o) where
   type Gradient (FullyConnected i o) = (FullyConnected' i o)
 
-  runUpdate LearningParameters {..} (FullyConnected (FullyConnected' oldBias oldActivations) (FullyConnected' oldBiasMomentum oldMomentum)) (FullyConnected' biasGradient activationGradient) =
-    let (newBias, newBiasMomentum)    = descendVector learningRate learningMomentum learningRegulariser oldBias biasGradient oldBiasMomentum
-        (newActivations, newMomentum) = descendMatrix learningRate learningMomentum learningRegulariser oldActivations activationGradient oldMomentum
+  runUpdate lp (FullyConnected (FullyConnected' oldBias oldActivations) (FullyConnected' oldBiasMomentum oldMomentum)) (FullyConnected' biasGradient activationGradient) =
+    let (newBias, newBiasMomentum)    = descendVector (learningRate lp) (learningMomentum lp) (learningRegulariser lp) oldBias biasGradient oldBiasMomentum
+        (newActivations, newMomentum) = descendMatrix (learningRate lp) (learningMomentum lp) (learningRegulariser lp) oldActivations activationGradient oldMomentum
     in FullyConnected (FullyConnected' newBias newActivations) (FullyConnected' newBiasMomentum newMomentum)
 
   createRandom = randomFullyConnected

--- a/src/Grenade/Recurrent/Core/Runner.hs
+++ b/src/Grenade/Recurrent/Core/Runner.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE RankNTypes            #-}
-{-# LANGUAGE RecordWildCards       #-}
 
 module Grenade.Recurrent.Core.Runner (
     runRecurrentExamples
@@ -101,11 +100,11 @@ updateRecInputs :: Fractional (RecurrentInputs sublayers)
                 -> RecurrentInputs sublayers
                 -> RecurrentInputs sublayers
 
-updateRecInputs l@LearningParameters {..} (() :~~+> xs) (() :~~+> ys)
-  = () :~~+> updateRecInputs l xs ys
+updateRecInputs lp (() :~~+> xs) (() :~~+> ys)
+  = () :~~+> updateRecInputs lp xs ys
 
-updateRecInputs l@LearningParameters {..} (x :~@+> xs) (y :~@+> ys)
-  = (realToFrac (1 - learningRate * learningRegulariser) * x - realToFrac learningRate * y) :~@+> updateRecInputs l xs ys
+updateRecInputs lp (x :~@+> xs) (y :~@+> ys)
+  = (realToFrac (1 - learningRate lp * learningRegulariser lp) * x - realToFrac (learningRate lp) * y) :~@+> updateRecInputs lp xs ys
 
 updateRecInputs _ RINil RINil
   = RINil

--- a/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
+++ b/src/Grenade/Recurrent/Layers/BasicRecurrent.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
-{-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -60,11 +59,11 @@ instance Show (BasicRecurrent i o) where
 instance (KnownNat i, KnownNat o, KnownNat (i + o)) => UpdateLayer (BasicRecurrent i o) where
   type Gradient (BasicRecurrent i o) = (BasicRecurrent' i o)
 
-  runUpdate LearningParameters {..} (BasicRecurrent oldBias oldBiasMomentum oldActivations oldMomentum) (BasicRecurrent' biasGradient activationGradient) =
-    let newBiasMomentum = konst learningMomentum * oldBiasMomentum - konst learningRate * biasGradient
+  runUpdate lp (BasicRecurrent oldBias oldBiasMomentum oldActivations oldMomentum) (BasicRecurrent' biasGradient activationGradient) =
+    let newBiasMomentum = konst (learningMomentum lp) * oldBiasMomentum - konst (learningRate lp) * biasGradient
         newBias         = oldBias + newBiasMomentum
-        newMomentum     = konst learningMomentum * oldMomentum - konst learningRate * activationGradient
-        regulariser     = konst (learningRegulariser * learningRate) * oldActivations
+        newMomentum     = konst (learningMomentum lp) * oldMomentum - konst (learningRate lp) * activationGradient
+        regulariser     = konst (learningRegulariser lp * learningRate lp) * oldActivations
         newActivations  = oldActivations + newMomentum - regulariser
     in BasicRecurrent newBias newBiasMomentum newActivations newMomentum
 


### PR DESCRIPTION
`RecordWildCards` has a small benefit when writing code and zero or negative benefits when writing code. In fact, `RWC` can make complex code significantly more difficult to read.